### PR TITLE
Add blog post scaffold workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This repository is a Jekyll blog, not a general app workspace. Keep production c
 ## Build, Test, and Development Commands
 
 - `bundle install`: install Ruby gems from `Gemfile`.
+- `bin/new-post "Post Title" --description "Summary" --tags "tag1,tag2"`: create a correctly named post scaffold in `_posts/`.
 - `bundle exec jekyll serve`: run the site locally at `http://localhost:4000`.
 - `bundle exec jekyll build`: generate the production site into `_site/`.
 - `bundle exec rake` or `bundle exec rake test`: build the site and run `html-proofer` checks against `_site/`.
@@ -27,4 +28,4 @@ Recent history uses short conventional commit subjects like `feat:`, `fix:`, and
 
 ## Content & Repo Hygiene
 
-Posts and pages should keep concise front matter with fields the layouts already use, such as `layout`, `title`, `description`, `date`, and `tags`. Do not commit `_site/`; it is generated output from `bundle exec jekyll build`. Also keep local editor settings, planning artifacts, and agent-specific workspace files out of the repository.
+Use `bin/new-post` for new posts so filenames and front matter stay consistent. Posts and pages should keep concise front matter with fields the layouts already use, such as `layout`, `title`, `description`, `date`, and `tags`. Do not commit `_site/`; it is generated output from `bundle exec jekyll build`. Also keep local editor settings, planning artifacts, and agent-specific workspace files out of the repository.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Field Notes
+# Chaitanya Khoje Blog
 
-Field Notes is a Jekyll-powered personal engineering blog published via GitHub Pages.
+This is Chaitanya Khoje's Jekyll-powered personal engineering blog, published via GitHub Pages.
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ bundle exec jekyll serve
 
 Open `http://localhost:4000`.
 
+## New posts
+
+Create a post scaffold:
+
+```bash
+bin/new-post "My Post Title" \
+  --description "Short summary for cards and SEO." \
+  --tags "ruby,jekyll,writing"
+```
+
+The command creates `_posts/YYYY-MM-DD-my-post-title.md` with front matter that matches the current layouts. Use `--date YYYY-MM-DD` to backdate or schedule a post.
+
 ## Verification
 
 Build the site:
@@ -40,6 +52,7 @@ The Rake task builds `_site/` and runs `html-proofer` against the generated outp
 
 - `_posts/` contains published posts in Jekyll post format.
 - `_layouts/` contains the site layouts for the home page and post pages.
+- `bin/new-post` creates correctly named post drafts.
 - `assets/css/blog.css` contains the shared site styles.
 - `assets/images/` contains blog and social imagery used by the site.
 - `_config.yml` contains site metadata, plugins, and permalink settings.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'html-proofer'
 
 task :test do
+  sh "ruby -Itest test/new_post_test.rb"
   sh "bundle exec jekyll build"
   HTMLProofer.check_directory("./_site", {
     assume_extension:    true,

--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,11 @@
-title: "Field Notes"
+title: "Chaitanya Khoje Blog"
 tagline: "Engineering, written down."
 author:
   name: "Chaitanya Khoje"
   email: "chaitanyakhoje9@gmail.com"
   github: "chaitanyakhoje"
 description: >-
-  Field Notes by Chaitanya Khoje. Software engineering observations —
+  Chaitanya Khoje's personal engineering blog. Software engineering observations —
   performance, databases, Rust, Go, craft.
 baseurl: ""
 url: "https://chaitanyakhoje.github.io"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@
     <div class="nav-inner">
       <a class="nav-logo" href="{{ '/' | relative_url }}">
         <div class="nav-logo-mark">C</div>
-        <span class="nav-logo-text">chaitanya / field notes</span>
+        <span class="nav-logo-text">chaitanya / blog</span>
       </a>
       <div class="nav-links">
         <a class="nav-link {% if page.url == '/' %}active{% endif %}" href="{{ '/' | relative_url }}">Posts</a>

--- a/bin/new-post
+++ b/bin/new-post
@@ -1,0 +1,90 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "date"
+require "optparse"
+
+options = {
+  date: Date.today.iso8601,
+  description: "",
+  tags: []
+}
+
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: bin/new-post \"Post Title\" [options]"
+
+  opts.on("--date DATE", "Post date in YYYY-MM-DD format") do |date|
+    options[:date] = Date.iso8601(date).iso8601
+  rescue Date::Error
+    warn "error: --date must use YYYY-MM-DD"
+    exit 1
+  end
+
+  opts.on("--description TEXT", "Short post summary for cards and SEO") do |description|
+    options[:description] = description.strip
+  end
+
+  opts.on("--tags TAGS", "Comma-separated tags, e.g. ruby,jekyll") do |tags|
+    options[:tags] = tags.split(",").map { |tag| tag.strip.downcase }.reject(&:empty?)
+  end
+end
+
+parser.parse!
+
+title = ARGV.join(" ").strip
+if title.empty?
+  warn parser
+  exit 1
+end
+
+def slugify(value)
+  value
+    .downcase
+    .gsub(/[^a-z0-9]+/, "-")
+    .gsub(/\A-|-+\z/, "")
+end
+
+def yaml_quote(value)
+  %("#{value.gsub("\\", "\\\\\\").gsub('"', '\"')}")
+end
+
+slug = slugify(title)
+if slug.empty?
+  warn "error: title must contain at least one letter or number"
+  exit 1
+end
+
+posts_dir = File.join(Dir.pwd, "_posts")
+unless Dir.exist?(posts_dir)
+  warn "error: _posts directory not found; run from the repository root"
+  exit 1
+end
+
+path = File.join(posts_dir, "#{options[:date]}-#{slug}.md")
+if File.exist?(path)
+  warn "error: #{path} already exists"
+  exit 1
+end
+
+front_matter = [
+  "---",
+  "layout: post",
+  "title: #{yaml_quote(title)}",
+  "description: #{yaml_quote(options[:description])}",
+  "tags: [#{options[:tags].join(", ")}]",
+  "date: #{options[:date]}",
+  "---"
+]
+
+body = <<~MARKDOWN
+
+  Write the opening paragraph here.
+
+  ## Notes
+
+  - Capture the core idea.
+  - Add examples, code, or links as needed.
+MARKDOWN
+
+File.write(path, "#{front_matter.join("\n")}#{body}")
+puts "created #{path}"

--- a/test/new_post_test.rb
+++ b/test/new_post_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "date"
+require "fileutils"
+require "open3"
+require "tmpdir"
+require "minitest/autorun"
+
+class NewPostTest < Minitest::Test
+  ROOT = File.expand_path("..", __dir__)
+  SCRIPT = File.join(ROOT, "bin", "new-post")
+
+  def setup
+    @tmpdir = Dir.mktmpdir("new-post-test")
+    FileUtils.mkdir_p(File.join(@tmpdir, "_posts"))
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  def run_new_post(*args)
+    Open3.capture3("ruby", SCRIPT, *args, chdir: @tmpdir)
+  end
+
+  def test_creates_post_with_expected_front_matter
+    stdout, stderr, status = run_new_post(
+      "My First Post!",
+      "--date", "2026-05-03",
+      "--description", "A short post summary.",
+      "--tags", "ruby, jekyll, writing"
+    )
+
+    assert status.success?, stderr
+    path = File.join(@tmpdir, "_posts", "2026-05-03-my-first-post.md")
+    assert File.exist?(path), stdout
+
+    content = File.read(path)
+    assert_includes content, "layout: post"
+    assert_includes content, 'title: "My First Post!"'
+    assert_includes content, 'description: "A short post summary."'
+    assert_includes content, "tags: [ruby, jekyll, writing]"
+    assert_includes content, "date: 2026-05-03"
+    assert_includes content, "## Notes"
+  end
+
+  def test_refuses_to_overwrite_existing_post
+    existing = File.join(@tmpdir, "_posts", "2026-05-03-my-post.md")
+    File.write(existing, "keep me")
+
+    _stdout, stderr, status = run_new_post("My Post", "--date", "2026-05-03")
+
+    refute status.success?
+    assert_equal "keep me", File.read(existing)
+    assert_includes stderr, "already exists"
+  end
+end


### PR DESCRIPTION
## What changed
- added `bin/new-post` to scaffold Jekyll blog posts with consistent filenames and front matter
- added focused tests for the scaffold command and wired them into `bundle exec rake test`
- documented the new post workflow in `README.md` and `AGENTS.md`
- renamed unclear "Field Notes" wording to direct Chaitanya Khoje blog naming in docs and site metadata

## Why
Adding posts by hand means manually choosing a dated filename, slug, front matter, tags, and body scaffold. This command makes that repeatable while keeping the site as a simple version-controlled Jekyll blog.

## Validation
- `ruby -Itest test/new_post_test.rb` passes
- full `bundle exec rake test` is still blocked locally because this shell is on Ruby 2.6 while the Jekyll/html-proofer bundle expects Ruby 3.2
