### PR TITLE
Align homepage with resume profile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,12 @@
 title: "Chaitanya Khoje Blog"
-tagline: "Engineering, written down."
+tagline: "Senior software engineer focused on data platforms, AI systems, and production efficiency."
 author:
   name: "Chaitanya Khoje"
   email: "chaitanyakhoje9@gmail.com"
   github: "chaitanyakhoje"
 description: >-
-  Chaitanya Khoje's personal engineering blog. Software engineering observations —
-  performance, databases, Rust, Go, craft.
+  Chaitanya Khoje's personal site and engineering blog. Senior software engineer
+  focused on data platforms, AI systems, measurement pipelines, and production efficiency.
 baseurl: ""
 url: "https://chaitanyakhoje.github.io"
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,34 +9,89 @@ layout: default
     <div>
       <div class="hero-status fade-in">
         <span class="status-dot"></span>
-        <span class="hero-status-text">Writing regularly · since 2024</span>
+        <span class="hero-status-text">Senior Software Engineer · Sunnyvale, CA</span>
       </div>
-      <h1 class="hero-title fade-in fade-in-1">Engineering,<br>written down.</h1>
+      <h1 class="hero-title fade-in fade-in-1">Data platforms,<br>AI systems, production scale.</h1>
       <p class="hero-bio fade-in fade-in-2">
-        Software engineer. I write about the parts of building software that nobody puts in the changelog.
+        I build large-scale measurement pipelines, AI-assisted engineering tools, and reliable data systems across ad platforms, warehouses, and cloud infrastructure.
       </p>
+      <div class="hero-actions fade-in fade-in-3">
+        <a class="btn btn-primary" href="mailto:chaitanyakhoje9@gmail.com">Email</a>
+        <a class="btn" href="https://www.linkedin.com/in/chaitanyakhoje/" target="_blank" rel="noopener">LinkedIn</a>
+        <a class="btn" href="https://github.com/ChaitanyaKhoje" target="_blank" rel="noopener">GitHub</a>
+      </div>
     </div>
     <div class="hero-card fade-in fade-in-2">
-      <p class="hero-card-label">↳ Cross-posted to</p>
-      <ul class="platform-list">
-        <li class="platform-item">
-          <span class="platform-dot" style="background:#0a0a0a;border:1px solid #555"></span>
-          <span class="platform-name">dev.to/chaitanyakhoje</span>
-          <span class="platform-arrow">↗</span>
-        </li>
-        <li class="platform-item">
-          <span class="platform-dot" style="background:#1a8917"></span>
-          <span class="platform-name">medium.com/@chaitanyakhoje</span>
-          <span class="platform-arrow">↗</span>
-        </li>
-        <li class="platform-item">
-          <span class="platform-dot" style="background:#ff6719"></span>
-          <span class="platform-name">chaitanyakhoje.substack.com</span>
-          <span class="platform-arrow">↗</span>
-        </li>
-      </ul>
+      <p class="hero-card-label">Current focus</p>
+      <p class="hero-card-title">Senior Software Engineer at Zefr</p>
+      <p class="hero-card-copy">
+        Owning production measurement pipelines across major ad platforms with Airflow, dbt, Snowflake, BigQuery, GCP, and AWS.
+      </p>
     </div>
   </section>
+
+  <section class="impact-grid fade-in fade-in-3" aria-label="Resume highlights">
+    <div class="impact-item">
+      <span class="impact-value">6+</span>
+      <span class="impact-label">years in data engineering and platforms</span>
+    </div>
+    <div class="impact-item">
+      <span class="impact-value">98.5%</span>
+      <span class="impact-label">pod reduction in a production ingestion system</span>
+    </div>
+    <div class="impact-item">
+      <span class="impact-value">95%</span>
+      <span class="impact-label">latency reduction for ad set data fetches</span>
+    </div>
+    <div class="impact-item">
+      <span class="impact-value">280</span>
+      <span class="impact-label">merged PRs across 27 repositories last year</span>
+    </div>
+  </section>
+
+  <section class="profile-grid fade-in fade-in-4">
+    <article class="profile-panel">
+      <p class="section-kicker">Experience</p>
+      <h2 class="section-title">Production data systems with measurable business impact.</h2>
+      <div class="timeline-list">
+        <div class="timeline-item">
+          <span class="timeline-date">2021 - Present</span>
+          <div>
+            <h3>Zefr · Senior Software Engineer</h3>
+            <p>Led measurement platform work across ingestion, transformation, warehouse modeling, reporting APIs, platform integrations, and AI-powered production tooling.</p>
+          </div>
+        </div>
+        <div class="timeline-item">
+          <span class="timeline-date">2020 - 2021</span>
+          <div>
+            <h3>realtor.com · Data Engineer</h3>
+            <p>Built AWS data pipelines, CloudFormation workflows, and CI/CD automation while cutting EMR spend by 74% through rightsizing and consolidation.</p>
+          </div>
+        </div>
+      </div>
+    </article>
+    <article class="profile-panel">
+      <p class="section-kicker">Tooling</p>
+      <h2 class="section-title">Python, SQL, Airflow, dbt, Snowflake, BigQuery, GCP, and AWS.</h2>
+      <div class="skill-cloud">
+        <span>Python</span>
+        <span>SQL</span>
+        <span>Airflow</span>
+        <span>dbt</span>
+        <span>Snowflake</span>
+        <span>BigQuery</span>
+        <span>Vertex AI</span>
+        <span>Kubernetes</span>
+        <span>Kafka</span>
+        <span>Datadog</span>
+      </div>
+    </article>
+  </section>
+
+  <div class="posts-heading fade-in fade-in-4">
+    <p class="section-kicker">Writing</p>
+    <h2 class="section-title">Engineering notes from production work.</h2>
+  </div>
 
   <!-- Tag filter -->
   <div class="tag-filters fade-in fade-in-3" id="tag-filters">

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -169,6 +169,13 @@ body {
   text-wrap: pretty;
 }
 
+.hero-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 26px;
+  flex-wrap: wrap;
+}
+
 .hero-card {
   background: var(--surface);
   border: 1px solid var(--rule);
@@ -181,6 +188,19 @@ body {
   color: var(--ink-soft);
   margin-bottom: 12px;
   font-family: var(--mono);
+}
+
+.hero-card-title {
+  font-size: 20px;
+  line-height: 1.2;
+  font-weight: 600;
+  letter-spacing: 0;
+  margin-bottom: 10px;
+}
+
+.hero-card-copy {
+  color: var(--ink-soft);
+  font-size: 14px;
 }
 
 .platform-list { list-style: none; display: flex; flex-direction: column; gap: 8px; }
@@ -197,6 +217,135 @@ body {
 .platform-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
 .platform-name { color: var(--ink-soft); font-family: var(--mono); font-size: 12px; }
 .platform-arrow { margin-left: auto; font-size: 11px; color: var(--ink-faint); }
+
+/* ── Profile sections ─────────────────────────────────── */
+.impact-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-bottom: 48px;
+}
+
+@media (max-width: 860px) {
+  .impact-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 520px) {
+  .impact-grid { grid-template-columns: 1fr; }
+}
+
+.impact-item,
+.profile-panel {
+  border: 1px solid var(--rule);
+  background: var(--surface);
+  border-radius: 12px;
+}
+
+.impact-item {
+  padding: 18px;
+  min-height: 128px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.impact-value {
+  font-size: 30px;
+  line-height: 1;
+  font-weight: 650;
+  letter-spacing: 0;
+}
+
+.impact-label {
+  color: var(--ink-soft);
+  font-size: 13px;
+}
+
+.profile-grid {
+  display: grid;
+  grid-template-columns: 1.35fr 1fr;
+  gap: 14px;
+  margin-bottom: 52px;
+}
+
+@media (max-width: 760px) {
+  .profile-grid { grid-template-columns: 1fr; }
+}
+
+.profile-panel {
+  padding: 24px;
+}
+
+.section-kicker {
+  font-size: 12px;
+  color: var(--ink-faint);
+  font-family: var(--mono);
+  margin-bottom: 10px;
+  text-transform: uppercase;
+}
+
+.section-title {
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 1.18;
+  letter-spacing: 0;
+  text-wrap: balance;
+}
+
+.timeline-list {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 104px 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 540px) {
+  .timeline-item { grid-template-columns: 1fr; gap: 6px; }
+}
+
+.timeline-date {
+  color: var(--ink-faint);
+  font-family: var(--mono);
+  font-size: 11px;
+  padding-top: 3px;
+}
+
+.timeline-item h3 {
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.timeline-item p {
+  color: var(--ink-soft);
+  font-size: 14px;
+}
+
+.skill-cloud {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 24px;
+}
+
+.skill-cloud span {
+  font-size: 12px;
+  color: var(--ink-soft);
+  border: 1px solid var(--rule);
+  background: var(--elev);
+  border-radius: 6px;
+  padding: 5px 9px;
+}
+
+.posts-heading {
+  margin-bottom: 22px;
+}
 
 /* ── Tag filter ───────────────────────────────────────── */
 .tag-filters {


### PR DESCRIPTION
## What changed
- updated homepage hero copy to reflect Chaitanya's senior data/platform engineering profile
- added resume-backed impact metrics for years of experience, ingestion efficiency, latency reduction, and merged PR volume
- added experience and tooling sections based on the resume
- updated site metadata description/tagline for the resume-aligned positioning
- kept blog posts separate; no new post was added

## Why
The homepage was still mostly generic blog positioning. The resume shows a stronger professional profile around large-scale measurement pipelines, AI/ML tooling, performance/cost optimization, and production reliability, so the site should lead with that.

## Validation
- extracted resume content from `/Users/chaitanya/Downloads/Chaitanya_Khoje_Resume (1).docx` with `textutil`
- `ruby -Itest test/new_post_test.rb` passes
- `bundle exec jekyll build` is blocked locally because the bundle is not installed under this shell's Ruby 2.6/Bundler 1.17 environment; the repo expects Ruby 3.2
