### PR TITLE
Add light mode toggle and improve new-post workflow

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,9 +57,15 @@
         }
       }
 
-      // Sync icon with current theme on load
+      // Sync icon with current theme on load (don't write localStorage here)
       var current = document.documentElement.getAttribute('data-theme') || 'dark';
-      applyTheme(current);
+      if (current === 'light') {
+        sun.style.display = 'block';
+        moon.style.display = 'none';
+      } else {
+        sun.style.display = 'none';
+        moon.style.display = 'block';
+      }
 
       btn.addEventListener('click', function() {
         var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,300;0,14..32,400;0,14..32,500;0,14..32,600;0,14..32,700;1,14..32,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script>
+    (function() {
+      var saved = localStorage.getItem('theme');
+      var preferred = saved || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', preferred);
+    })();
+  </script>
   <link rel="stylesheet" href="{{ '/assets/css/blog.css' | relative_url }}" />
   {% seo %}
 </head>
@@ -22,11 +29,44 @@
       <div class="nav-links">
         <a class="nav-link {% if page.url == '/' %}active{% endif %}" href="{{ '/' | relative_url }}">Posts</a>
         <a class="nav-link" href="https://github.com/chaitanyakhoje" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" id="theme-toggle" aria-label="Toggle light/dark mode" title="Toggle theme">
+          <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+          <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        </button>
       </div>
     </div>
   </nav>
 
   {{ content }}
+
+  <script>
+    (function() {
+      var btn = document.getElementById('theme-toggle');
+      var sun = document.getElementById('icon-sun');
+      var moon = document.getElementById('icon-moon');
+
+      function applyTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        if (theme === 'light') {
+          sun.style.display = 'block';
+          moon.style.display = 'none';
+        } else {
+          sun.style.display = 'none';
+          moon.style.display = 'block';
+        }
+      }
+
+      // Sync icon with current theme on load
+      var current = document.documentElement.getAttribute('data-theme') || 'dark';
+      applyTheme(current);
+
+      btn.addEventListener('click', function() {
+        var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        applyTheme(next);
+      });
+    })();
+  </script>
 
 </body>
 </html>

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -803,3 +803,22 @@ body {
   .fade-in, .fade-in-1, .fade-in-2, .fade-in-3, .fade-in-4 { animation: none; }
   .modal-box { animation: none; }
 }
+
+/* ── Light theme (warm paper) ─────────────────────────── */
+[data-theme="light"] {
+  --bg:        #faf9f7;
+  --surface:   #f5f3ef;
+  --elev:      #ffffff;
+  --ink:       #1c1917;
+  --ink-soft:  #57534e;
+  --ink-faint: #a8a29e;
+  --rule:      #e7e5e4;
+}
+
+[data-theme="light"] .topbar {
+  background: rgba(250,249,247,0.88);
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb {
+  background: #c7c4c1;
+}

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -108,6 +108,21 @@ body {
 .nav-link:hover { background: var(--surface); color: var(--ink); }
 .nav-link.active { background: var(--surface); color: var(--ink); }
 
+.theme-toggle {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--ink-soft);
+  padding: 6px 8px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  transition: background 0.12s, color 0.12s;
+}
+
+.theme-toggle:hover { background: var(--surface); color: var(--ink); }
+.theme-toggle svg { display: block; }
+
 /* ── Home hero ────────────────────────────────────────── */
 .home-wrap {
   max-width: 1100px;

--- a/bin/new-post
+++ b/bin/new-post
@@ -31,12 +31,6 @@ end
 
 parser.parse!
 
-title = ARGV.join(" ").strip
-if title.empty?
-  warn parser
-  exit 1
-end
-
 def slugify(value)
   value
     .downcase
@@ -46,6 +40,35 @@ end
 
 def yaml_quote(value)
   %("#{value.gsub("\\", "\\\\\\").gsub('"', '\"')}")
+end
+
+def prompt(label, required: false)
+  loop do
+    $stdout.print "#{label}: "
+    $stdout.flush
+    value = $stdin.gets&.strip || ""
+    return value unless required && value.empty?
+    warn "  (required)"
+  end
+end
+
+def open_in_editor(path)
+  editor = ENV["EDITOR"]
+  editor ||= %w[code cursor vim].find { |e| system("which #{e} > /dev/null 2>&1") }
+  return unless editor
+  system("#{editor} #{path}")
+end
+
+title = ARGV.join(" ").strip
+
+if title.empty?
+  # Interactive mode
+  puts ""
+  title = prompt("Title", required: true)
+  options[:description] = prompt("Description (optional)")
+  raw_tags = prompt("Tags, comma-separated (optional)")
+  options[:tags] = raw_tags.split(",").map { |t| t.strip.downcase }.reject(&:empty?)
+  puts ""
 end
 
 slug = slugify(title)
@@ -78,13 +101,19 @@ front_matter = [
 
 body = <<~MARKDOWN
 
-  Write the opening paragraph here.
+  Write the opening paragraph here — the hook that makes someone keep reading.
 
-  ## Notes
+  ## Background
 
-  - Capture the core idea.
-  - Add examples, code, or links as needed.
+  ## The Problem
+
+  ## Solution
+
+  ## Takeaways
+
+  -
 MARKDOWN
 
 File.write(path, "#{front_matter.join("\n")}#{body}")
 puts "created #{path}"
+open_in_editor(path)

--- a/bin/new-post
+++ b/bin/new-post
@@ -4,33 +4,6 @@
 require "date"
 require "optparse"
 
-options = {
-  date: Date.today.iso8601,
-  description: "",
-  tags: []
-}
-
-parser = OptionParser.new do |opts|
-  opts.banner = "Usage: bin/new-post \"Post Title\" [options]"
-
-  opts.on("--date DATE", "Post date in YYYY-MM-DD format") do |date|
-    options[:date] = Date.iso8601(date).iso8601
-  rescue Date::Error
-    warn "error: --date must use YYYY-MM-DD"
-    exit 1
-  end
-
-  opts.on("--description TEXT", "Short post summary for cards and SEO") do |description|
-    options[:description] = description.strip
-  end
-
-  opts.on("--tags TAGS", "Comma-separated tags, e.g. ruby,jekyll") do |tags|
-    options[:tags] = tags.split(",").map { |tag| tag.strip.downcase }.reject(&:empty?)
-  end
-end
-
-parser.parse!
-
 def slugify(value)
   value
     .downcase
@@ -52,12 +25,49 @@ def prompt(label, required: false)
   end
 end
 
+def normalize_tags(raw)
+  raw.split(",").map { |t| t.strip.downcase }.reject(&:empty?)
+end
+
+def editor_available?(name)
+  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).any? do |dir|
+    File.executable?(File.join(dir, name))
+  end
+end
+
 def open_in_editor(path)
   editor = ENV["EDITOR"]
-  editor ||= %w[code cursor vim].find { |e| system("which #{e} > /dev/null 2>&1") }
+  editor ||= %w[code cursor vim].find { |e| editor_available?(e) }
   return unless editor
-  system("#{editor} #{path}")
+  system(editor, path)
 end
+
+options = {
+  date: Date.today.iso8601,
+  description: "",
+  tags: []
+}
+
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: bin/new-post \"Post Title\" [options]"
+
+  opts.on("--date DATE", "Post date in YYYY-MM-DD format") do |date|
+    options[:date] = Date.iso8601(date).iso8601
+  rescue Date::Error
+    warn "error: --date must use YYYY-MM-DD"
+    exit 1
+  end
+
+  opts.on("--description TEXT", "Short post summary for cards and SEO") do |description|
+    options[:description] = description.strip
+  end
+
+  opts.on("--tags TAGS", "Comma-separated tags, e.g. ruby,jekyll") do |tags|
+    options[:tags] = normalize_tags(tags)
+  end
+end
+
+parser.parse!
 
 title = ARGV.join(" ").strip
 
@@ -67,7 +77,7 @@ if title.empty?
   title = prompt("Title", required: true)
   options[:description] = prompt("Description (optional)")
   raw_tags = prompt("Tags, comma-separated (optional)")
-  options[:tags] = raw_tags.split(",").map { |t| t.strip.downcase }.reject(&:empty?)
+  options[:tags] = normalize_tags(raw_tags)
   puts ""
 end
 

--- a/docs/superpowers/plans/2026-05-03-light-mode-blog-workflow.md
+++ b/docs/superpowers/plans/2026-05-03-light-mode-blog-workflow.md
@@ -1,0 +1,421 @@
+# Light Mode Toggle + Blog Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a warm-paper light mode toggle to the blog nav, and improve `bin/new-post` with interactive prompts and auto-open.
+
+**Architecture:** Light mode uses a `[data-theme="light"]` CSS block overriding `:root` variables; a no-flash inline script in `<head>` applies the theme before paint; a toggle button in the nav switches and persists the preference. The `bin/new-post` script gains an interactive path (triggered when no args) and auto-open logic, leaving the existing CLI flags intact.
+
+**Tech Stack:** Jekyll/Liquid, vanilla CSS custom properties, vanilla JS, Ruby stdlib (`io/console` not needed — plain `gets`)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `assets/css/blog.css` | Modify (append) | Add `[data-theme="light"]` variable block + `.theme-toggle` button styles + light scrollbar |
+| `_layouts/default.html` | Modify | Add no-flash inline script in `<head>`; add `.theme-toggle` button in nav; add theme JS at end of `<body>` |
+| `bin/new-post` | Modify | Add interactive prompt path + auto-open logic + richer body scaffold |
+
+---
+
+## Task 1: Light mode CSS variables
+
+**Files:**
+- Modify: `assets/css/blog.css` (append after line 790)
+
+- [ ] **Step 1: Append the light theme block to `assets/css/blog.css`**
+
+Add this at the very end of the file (after the `@media (prefers-reduced-motion)` block):
+
+```css
+/* ── Light theme (warm paper) ─────────────────────────── */
+[data-theme="light"] {
+  --bg:        #faf9f7;
+  --surface:   #f5f3ef;
+  --elev:      #ffffff;
+  --ink:       #1c1917;
+  --ink-soft:  #57534e;
+  --ink-faint: #a8a29e;
+  --rule:      #e7e5e4;
+}
+
+[data-theme="light"] .topbar {
+  background: rgba(250,249,247,0.88);
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb {
+  background: #c7c4c1;
+}
+```
+
+- [ ] **Step 2: Verify CSS variable names match `:root`**
+
+Run:
+```bash
+grep -n "^\s*--" assets/css/blog.css | head -20
+```
+Expected: variables like `--bg`, `--surface`, `--elev`, `--ink`, `--ink-soft`, `--ink-faint`, `--rule` appear in `:root`. Confirm the names in the new block are identical.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add assets/css/blog.css
+git commit -m "feat: add warm-paper light theme CSS variables"
+```
+
+---
+
+## Task 2: Theme toggle button styles
+
+**Files:**
+- Modify: `assets/css/blog.css` (insert in Nav section, after `.nav-link.active` line ~109)
+
+- [ ] **Step 1: Add `.theme-toggle` styles after `.nav-link.active` (around line 109)**
+
+Insert this block after the `.nav-link.active` rule:
+
+```css
+.theme-toggle {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--ink-soft);
+  padding: 6px 8px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  transition: background 0.12s, color 0.12s;
+}
+
+.theme-toggle:hover { background: var(--surface); color: var(--ink); }
+.theme-toggle svg { display: block; }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add assets/css/blog.css
+git commit -m "feat: add theme toggle button styles"
+```
+
+---
+
+## Task 3: No-flash script + toggle button + theme JS in default layout
+
+**Files:**
+- Modify: `_layouts/default.html`
+
+- [ ] **Step 1: Add no-flash inline script in `<head>` before the CSS link**
+
+In `_layouts/default.html`, insert this `<script>` block immediately before the `<link rel="stylesheet" ...>` line:
+
+```html
+  <script>
+    (function() {
+      var saved = localStorage.getItem('theme');
+      var preferred = saved || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', preferred);
+    })();
+  </script>
+```
+
+This must run before the stylesheet so the browser paints with the correct variables immediately.
+
+- [ ] **Step 2: Add the toggle button in the nav**
+
+In `_layouts/default.html`, find the `.nav-links` div:
+
+```html
+      <div class="nav-links">
+        <a class="nav-link {% if page.url == '/' %}active{% endif %}" href="{{ '/' | relative_url }}">Posts</a>
+        <a class="nav-link" href="https://github.com/chaitanyakhoje" target="_blank" rel="noopener">GitHub</a>
+      </div>
+```
+
+Replace it with:
+
+```html
+      <div class="nav-links">
+        <a class="nav-link {% if page.url == '/' %}active{% endif %}" href="{{ '/' | relative_url }}">Posts</a>
+        <a class="nav-link" href="https://github.com/chaitanyakhoje" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" id="theme-toggle" aria-label="Toggle light/dark mode" title="Toggle theme">
+          <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+          <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        </button>
+      </div>
+```
+
+The sun icon has `style="display:none"` initially (site defaults to dark, so moon is shown). JS will flip them.
+
+- [ ] **Step 3: Add theme toggle JS before `</body>`**
+
+In `_layouts/default.html`, insert this block immediately before `</body>`:
+
+```html
+  <script>
+    (function() {
+      var btn = document.getElementById('theme-toggle');
+      var sun = document.getElementById('icon-sun');
+      var moon = document.getElementById('icon-moon');
+
+      function applyTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        if (theme === 'light') {
+          sun.style.display = 'block';
+          moon.style.display = 'none';
+        } else {
+          sun.style.display = 'none';
+          moon.style.display = 'block';
+        }
+      }
+
+      // Sync icon with current theme on load
+      var current = document.documentElement.getAttribute('data-theme') || 'dark';
+      applyTheme(current);
+
+      btn.addEventListener('click', function() {
+        var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        applyTheme(next);
+      });
+    })();
+  </script>
+```
+
+- [ ] **Step 4: Verify the full `default.html` reads correctly**
+
+Run:
+```bash
+cat _layouts/default.html
+```
+
+Expected output contains (in order):
+1. `<script>` no-flash block before `<link rel="stylesheet"`
+2. `.theme-toggle` button with both SVG icons in `.nav-links`
+3. Theme toggle JS block before `</body>`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add _layouts/default.html
+git commit -m "feat: add light mode toggle to nav with no-flash script"
+```
+
+---
+
+## Task 4: Interactive mode + auto-open for `bin/new-post`
+
+**Files:**
+- Modify: `bin/new-post`
+
+- [ ] **Step 1: Rewrite `bin/new-post` with interactive path and auto-open**
+
+Replace the entire contents of `bin/new-post` with:
+
+```ruby
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "date"
+require "optparse"
+
+options = {
+  date: Date.today.iso8601,
+  description: "",
+  tags: []
+}
+
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: bin/new-post \"Post Title\" [options]"
+
+  opts.on("--date DATE", "Post date in YYYY-MM-DD format") do |date|
+    options[:date] = Date.iso8601(date).iso8601
+  rescue Date::Error
+    warn "error: --date must use YYYY-MM-DD"
+    exit 1
+  end
+
+  opts.on("--description TEXT", "Short post summary for cards and SEO") do |description|
+    options[:description] = description.strip
+  end
+
+  opts.on("--tags TAGS", "Comma-separated tags, e.g. ruby,jekyll") do |tags|
+    options[:tags] = tags.split(",").map { |tag| tag.strip.downcase }.reject(&:empty?)
+  end
+end
+
+parser.parse!
+
+def slugify(value)
+  value
+    .downcase
+    .gsub(/[^a-z0-9]+/, "-")
+    .gsub(/\A-|-+\z/, "")
+end
+
+def yaml_quote(value)
+  %("#{value.gsub("\\", "\\\\\\").gsub('"', '\"')}")
+end
+
+def prompt(label, required: false)
+  loop do
+    $stdout.print "#{label}: "
+    $stdout.flush
+    value = $stdin.gets&.strip || ""
+    return value unless required && value.empty?
+    warn "  (required)"
+  end
+end
+
+def open_in_editor(path)
+  editor = ENV["EDITOR"]
+  editor ||= %w[code cursor vim].find { |e| system("which #{e} > /dev/null 2>&1") }
+  return unless editor
+  system("#{editor} #{path}")
+end
+
+title = ARGV.join(" ").strip
+
+if title.empty?
+  # Interactive mode
+  puts ""
+  title = prompt("Title", required: true)
+  options[:description] = prompt("Description (optional)")
+  raw_tags = prompt("Tags, comma-separated (optional)")
+  options[:tags] = raw_tags.split(",").map { |t| t.strip.downcase }.reject(&:empty?)
+  puts ""
+end
+
+slug = slugify(title)
+if slug.empty?
+  warn "error: title must contain at least one letter or number"
+  exit 1
+end
+
+posts_dir = File.join(Dir.pwd, "_posts")
+unless Dir.exist?(posts_dir)
+  warn "error: _posts directory not found; run from the repository root"
+  exit 1
+end
+
+path = File.join(posts_dir, "#{options[:date]}-#{slug}.md")
+if File.exist?(path)
+  warn "error: #{path} already exists"
+  exit 1
+end
+
+front_matter = [
+  "---",
+  "layout: post",
+  "title: #{yaml_quote(title)}",
+  "description: #{yaml_quote(options[:description])}",
+  "tags: [#{options[:tags].join(", ")}]",
+  "date: #{options[:date]}",
+  "---"
+]
+
+body = <<~MARKDOWN
+
+  Write the opening paragraph here — the hook that makes someone keep reading.
+
+  ## Background
+
+  ## The Problem
+
+  ## Solution
+
+  ## Takeaways
+
+  - 
+MARKDOWN
+
+File.write(path, "#{front_matter.join("\n")}#{body}")
+puts "created #{path}"
+open_in_editor(path)
+```
+
+- [ ] **Step 2: Make the script executable (if not already)**
+
+```bash
+chmod +x bin/new-post
+```
+
+- [ ] **Step 3: Test flag-based path still works**
+
+```bash
+bin/new-post "Test Post Flag Mode" --description "A test" --tags "test,ruby"
+```
+
+Expected:
+```
+created _posts/2026-05-03-test-post-flag-mode.md
+```
+
+Verify the file exists and has the correct frontmatter:
+```bash
+head -8 _posts/2026-05-03-test-post-flag-mode.md
+```
+
+Expected:
+```yaml
+---
+layout: post
+title: "Test Post Flag Mode"
+description: "A test"
+tags: [test, ruby]
+date: 2026-05-03
+---
+```
+
+- [ ] **Step 4: Clean up test file**
+
+```bash
+rm _posts/2026-05-03-test-post-flag-mode.md
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/new-post
+git commit -m "feat: add interactive mode and auto-open to bin/new-post"
+```
+
+---
+
+## Task 5: Create branch and PR
+
+- [ ] **Step 1: Create and push the feature branch**
+
+```bash
+git checkout -b light-mode-blog-workflow
+git push -u origin light-mode-blog-workflow
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create \
+  --title "Add light mode toggle and improve new-post workflow" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds warm-paper light mode toggle to nav with sun/moon icon
+- No-flash script in `<head>` applies theme before paint; persists via `localStorage`; respects `prefers-color-scheme` on first visit
+- Improves `bin/new-post` with interactive prompts (no args = guided flow) and auto-open in `$EDITOR`
+
+## Test plan
+
+- [ ] Visit site — loads in dark mode by default
+- [ ] Click moon icon → switches to warm-paper light mode; icon flips to sun
+- [ ] Reload page → light mode persists
+- [ ] Click sun icon → back to dark; persists on reload
+- [ ] Open a new private window → OS dark preference loads dark; OS light preference loads light
+- [ ] Run `bin/new-post` with no args → interactive prompts appear; file created; editor opens
+- [ ] Run `bin/new-post "Title" --tags foo,bar` → works as before (no regression)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-03-light-mode-blog-workflow-design.md
+++ b/docs/superpowers/specs/2026-05-03-light-mode-blog-workflow-design.md
@@ -1,0 +1,82 @@
+# Design: Light Mode Toggle + Blog Workflow
+
+Date: 2026-05-03
+
+## Feature 1: Light Mode Toggle
+
+### Architecture
+
+- `data-theme` attribute on `<html>` element drives all theming
+- CSS variable overrides in `assets/css/blog.css` under `[data-theme="light"]`
+- No-flash script in `<head>` of `_layouts/default.html` (before CSS link) reads `localStorage` and applies `data-theme` synchronously
+- Toggle button in nav (right side, before GitHub link): sun/moon SVG icon, no label
+
+### Light Palette (warm paper)
+
+```
+--bg:        #faf9f7
+--surface:   #f5f3ef
+--elev:      #ffffff
+--ink:       #1c1917
+--ink-soft:  #57534e
+--ink-faint: #a8a29e
+--rule:      #e7e5e4
+--accent:    #3b59f7  (unchanged)
+```
+
+### Behavior
+
+1. **First visit**: read `prefers-color-scheme`. `dark` → dark mode (current default). `light` → light mode.
+2. **Toggle click**: flip theme, save to `localStorage("theme")`.
+3. **Return visits**: `localStorage` value wins over OS preference.
+4. **No flash**: inline `<script>` in `<head>` before CSS applies `data-theme` synchronously before paint.
+
+### Files Changed
+
+- `assets/css/blog.css` — add `[data-theme="light"]` block with warm palette overrides; update scrollbar thumb for light mode
+- `_layouts/default.html` — add no-flash inline script in `<head>`; add toggle button in nav with sun/moon SVG; add toggle JS
+
+---
+
+## Feature 2: `bin/new-post` Interactive Mode
+
+### Architecture
+
+- Existing flag-based CLI (`bin/new-post "Title" --tags foo,bar`) unchanged — no regressions
+- When run with no arguments: enter interactive mode, prompt one question at a time
+- After file creation: auto-open in editor
+
+### Interactive Flow
+
+```
+$ bin/new-post
+Title: The hidden cost of N+1 queries
+Description (optional): Why ORMs quietly destroy your DB at scale
+Tags (comma-separated, optional): postgres, databases, performance
+→ created _posts/2026-05-03-the-hidden-cost-of-n-1-queries.md
+→ opening in editor...
+```
+
+### Auto-Open Logic
+
+Try in order: `$EDITOR` env var → `code` → `cursor` → `vim`. Always print the path regardless.
+
+### Body Scaffold (replaces current placeholder)
+
+```markdown
+Write the opening paragraph here — the hook that makes someone keep reading.
+
+## Background
+
+## The Problem
+
+## Solution
+
+## Takeaways
+
+- 
+```
+
+### Files Changed
+
+- `bin/new-post` — add interactive prompt path (triggered when `ARGV` is empty after `parse!`); add auto-open logic; update body scaffold


### PR DESCRIPTION
## Summary

- Adds warm-paper light mode toggle to nav with sun/moon icon
- No-flash script in `<head>` applies theme before paint; persists via `localStorage` only on explicit toggle; respects `prefers-color-scheme` on first visit
- Improves `bin/new-post` with interactive prompts (no args = guided flow) and auto-open in `$EDITOR`
- Fixes shell injection in `open_in_editor` (array-form `system`)

## Test plan

- [ ] Visit site — loads in dark mode by default (or light if OS set to light)
- [ ] Click moon icon → switches to warm-paper light mode; icon flips to sun
- [ ] Reload page → light mode persists
- [ ] Click sun icon → back to dark; persists on reload
- [ ] Open a new private window → OS dark preference loads dark; OS light preference loads light; changing OS preference later respected (not locked to localStorage)
- [ ] Run `bin/new-post` with no args → interactive prompts appear; file created in `_posts/`; editor opens
- [ ] Run `bin/new-post "Title" --tags foo,bar` → works as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)