### PR TITLE
feat: add Observatory Notebook layout for astrophotography workflow p…

### DIFF
--- a/.superpowers/skills/new-astro-post.md
+++ b/.superpowers/skills/new-astro-post.md
@@ -1,0 +1,275 @@
+---
+name: new-astro-post
+description: Create a new astrophotography workflow post for chaitanyakhoje.github.io. Parses PixInsight WBPP logs, extracts session stats, and scaffolds a structured post using the astro-workflow layout with a sticky gear sidebar.
+---
+
+# new-astro-post
+
+Create a structured astrophotography workflow post from a PixInsight WBPP session.
+
+## When to use
+
+Invoke this skill whenever the user wants to document a new astrophotography processing session. It ensures every post is consistent in structure, front matter, and depth.
+
+## Required inputs
+
+The user must provide at least one of:
+- Path(s) to WBPP log files (`*.log`, `ProcessLogger.txt`)
+- Gear used (scope, camera, mount, filter, software)
+- Target name
+
+Everything else is derived from the logs or asked inline.
+
+## Step 1 — Parse the logs
+
+Read all provided log files. Extract:
+
+| Field | Where to find it |
+|-------|-----------------|
+| Target name | Filename pattern: `Light_<TARGET>_…` |
+| Frame count | `Group of N Light frames` |
+| Sensor size | `SIZE : WxH` |
+| Binning | `BINNING : N` |
+| Filter | `Filter : <name>` |
+| Exposure | `Exposure : N.NNs` |
+| Color mode | `Color : CFA` or `RGB` |
+| Demosaic method | `DB.debayerMethod = Debayer.<METHOD>` |
+| CFA pattern | `DB.cfaPattern = Debayer.<PATTERN>` |
+| Best reference frame | `Best reference frame: …` (filename + timestamp) |
+| Registered count | `Registration completed: N images out of M` |
+| Failed registrations | Lines matching `** Warning: Registration failed for image:` |
+| Local normalization | Presence/absence of `LOCAL NORMALIZATION` section |
+| Stacking method | Lines matching `INTEGRATION` section |
+
+Compute derived values:
+- **Rejected frames** = total − registered
+- **Rejection rate** = rejected / total × 100
+- **Total integration** = registered × exposure_seconds / 60 → format as `X min` or `X h Y min`
+
+Identify **failure clusters** by grouping failed frame timestamps (extract from filename `…_YYYYMMDD-HHMMSS_d.xisf`) into time windows. Flag if clusters appear at session start (mount settling), end (meridian flip, horizon), or mid-session (weather, tracking).
+
+## Step 2 — Ask for missing gear
+
+If the gear cannot be inferred from the logs, ask inline (plain text, not AskUserQuestion):
+
+```
+I have the capture stats from the logs. What gear did you use?
+Telescope/optics, camera, mount, filter(s), capture software — anything you want in the sidebar.
+```
+
+For ZWO Seestar S50 sessions, the gear is fully known:
+- **Telescope:** ZWO Seestar S50 · 250mm f/4.8
+- **Camera:** Built-in CMOS (1080×1920) · OSC / Bayer
+- **Mount:** Built-in EQ mode (motorized alt-az + field de-rotation)
+- **Filter:** Built-in LP (light pollution)
+- **Software:** Seestar app · PixInsight [version from log] · WBPP [version from log]
+
+## Step 3 — Generate the front matter
+
+Use this exact YAML structure. Every field maps directly to the Observatory Notebook layout's sidebar and hero section:
+
+```yaml
+---
+layout: astro-workflow
+theme: dark
+body_class: astro-page
+hide_theme_toggle: true
+title: "<TARGET_FULL_NAME> — <WORKFLOW_TYPE> Workflow"
+description: "<N> light frames through the <SCOPE> in <MOUNT_MODE>, stacked in PixInsight using <WORKFLOW_NAME> <with/without> local normalization."
+date: YYYY-MM-DD
+target: <TARGET_SHORT>
+object_type: "<Emission Nebula | Galaxy | Globular Cluster | etc.>"
+constellation: "<constellation name>"
+tags: [astrophotography, pixinsight, wbpp, <scope_tag>, <object_type>]
+
+# Optional: actual image paths (omit to use SVG placeholder)
+# hero_image: /assets/images/posts/<slug>/final.jpg
+# hero_image_caption: "Final processed image — <details>"
+# before_image: /assets/images/posts/<slug>/raw.jpg
+# after_image: /assets/images/posts/<slug>/final.jpg
+
+# Optional: margin note shown in hero aside
+margin_note: "<Short atmospheric field note from the session>"
+margin_note_date: "<Location or date — e.g. 'Backyard, Apr 18'>"
+
+gear:
+  telescope: "<scope> · <focal_length> <focal_ratio>"
+  camera: "<camera_name> (<resolution>) · <color_mode>"
+  mount: "<mount_name> (<mode if notable>)"
+  filter: "<filter_name>"
+  software: "<capture_sw> · <processing_sw> · <script_name>"
+
+capture:
+  frames: "<N> lights (<registered> registered)"
+  exposure: "<X> s per frame"
+  integration: "~<total_min> min total"
+  gain: "<gain_value or 'Seestar default'>"
+  location: "<city, state>"
+  date: "<Month D–D, YYYY>"
+  bortle: "<N> (<description>)"
+---
+```
+
+**Title conventions:**
+- Workflow type: `WBPP Preprocessing Workflow`, `Calibration Workflow`, `Integration Workflow`
+- Use the full common name for well-known objects: `M81 Bode's Galaxy`, `M42 Orion Nebula`, `NGC 7293 Helix Nebula`
+- For the `target` field use just the catalog ID: `M81`, `NGC 7293`
+
+**Tag conventions:**
+- Always include: `astrophotography`, `pixinsight`, `wbpp`
+- Add scope tag: `seestar` for Seestar S50, `refractor`, `reflector`, `newt` etc.
+- Add object type: `galaxy`, `nebula`, `cluster`, `planetary`
+
+## Step 4 — Write the post body
+
+Every workflow post MUST follow this exact section structure. Do not omit sections; use a `_To be documented._` placeholder if content is not yet available.
+
+```markdown
+## Target
+
+[2–3 sentences: what the object is, distance/size/magnitude, why it's interesting or why this target was chosen for this session.]
+
+---
+
+## Acquisition
+
+[1–2 sentences on how the mount/scope was set up for this session — any special modes, polar alignment approach, notable conditions.]
+
+[Acquisition summary table:]
+| Parameter | Value |
+|-----------|-------|
+| Date | ... |
+| Total frames | ... |
+| Filter | ... |
+| Sensor | ... |
+| Mode | CFA/RGB/Mono |
+| Calibration frames | None / Darks + Flats / ... |
+
+[1 sentence on calibration frame decision and why.]
+
+---
+
+## WBPP Run — Step by Step
+
+### 1. Light Frame Calibration
+
+[What WBPP did in this stage. Quote the group summary from the log. Explain if calibration masters were attached or not.]
+
+### 2. Debayering (Demosaicing)
+
+[Only include if CFA/OSC data. State the CFA pattern and debayering method chosen, and briefly explain why that method was used.]
+
+### 3. Image Measurements
+
+[Describe what WBPP measured and how those measurements feed into the weighting for stacking.]
+
+### 4. Reference Frame Selection
+
+[Quote the best reference frame path. Note the timestamp and what it likely represents (best seeing window, etc.).]
+
+### 5. Image Registration
+
+[State registered/total count and rejection rate. Describe the failure clusters by timestamp — what might have caused them. Assess whether the yield is acceptable.]
+
+### 6. Stacking (No Local Normalization) OR ### 6. Stacking (With Local Normalization)
+
+[Explain the stacking parameters chosen. For the local normalization decision specifically:]
+
+**With local normalization:** State why it was used — vignetting variation, no flat frames, alt-az field rotation producing gradient drift across the session.
+
+**Without local normalization:** State why it was skipped — flat frames present, tracking was consistent, target object type (extended nebulosity risk), or intentional test.
+
+[Describe the output: linear/stretched, color space, ready for next steps.]
+
+---
+
+## Results Summary
+
+| Stage | Input | Output |
+|-------|-------|--------|
+| Debayering | N CFA frames | N RGB frames |
+| Registration | N registered | N accepted · N rejected |
+| Stack integration | N × X s | ~Y min |
+
+**Yield: XX%** — [one-sentence assessment]
+
+---
+
+## Next Steps
+
+- [ ] Background extraction (DBE or ABE)
+- [ ] Color calibration (SPCC or manual white balance)
+- [ ] Noise reduction (NoiseXTerminator or MMT)
+- [ ] Stretch (HistogramTransformation or GHS)
+- [ ] Sharpening (DeconvolutionSpectralWeighting or UnsharpMask on luminance)
+- [ ] Final crop and export
+
+[Add or remove steps based on what was actually done and what remains.]
+
+---
+
+## Notes and Observations
+
+[Free-form: anything that stood out during the session or processing run. Tracking behavior, weather events visible in the registration failures, unusual rejection clusters, things to try differently next time. Include screenshot captions if screenshots are attached.]
+
+[For each attached screenshot, add:]
+![Screenshot description]({{ '/assets/images/posts/<slug>/<filename>' | relative_url }})
+*Caption: what the screenshot shows and why it matters.*
+```
+
+## Step 5 — Choose the filename and slug
+
+```
+YYYY-MM-DD-<target-slug>-<workflow-slug>.md
+```
+
+Examples:
+- `2026-05-17-m81-bodes-galaxy-wbpp-workflow.md`
+- `2026-06-01-m42-orion-nebula-wbpp-workflow.md`
+- `2026-07-15-ngc7293-helix-nebula-calibration-workflow.md`
+
+Use the post date (today's date by default, or the session date if specified).
+
+## Step 6 — Place screenshots
+
+If the user attaches screenshots during the conversation, place them at:
+
+```
+assets/images/posts/<post-slug>/<screenshot-filename>
+```
+
+Reference them in the **Notes and Observations** section using the pattern shown in Step 4.
+
+## Step 7 — Verify and create
+
+Before writing:
+1. Confirm target name and date with the user if ambiguous
+2. Write the file to `_posts/`
+3. Report: filename created, gear panel fields populated, word count, any log fields that could not be extracted (list them so the user can fill them in)
+
+## Layout reference — Observatory Notebook
+
+Posts using `layout: astro-workflow` render the **Observatory Notebook** design:
+
+- **Top bar:** sticky mono header with target, date, location
+- **Hero:** large title in monospace, field-data grid card (target/type/constellation/dates/integration/location), badges from `tags`, margin note aside
+- **Hero image:** full-width 16:9 frame with crosshair tick marks and corner brackets; uses `hero_image` if set, otherwise renders a deep-space SVG nebula placeholder
+- **Body grid:** 240px sticky sidebar + main content column
+- **Sidebar contains:**
+  1. Auto-generated scroll-spy TOC (built from `h2`/`h3` in the post body)
+  2. Quick Stats from `capture.*` front matter
+  3. Gear card from `gear.*` front matter (numbered rows, mono labels)
+- **Prose styles:** `.nb-prose` — serif body, monospace `h2` with `§` prefix, callout `blockquote`s, syntax-highlighted `pre`/`code`, markdown tables styled as acquisition tables
+- **Before/After slider:** rendered if both `before_image` and `after_image` are set in front matter; drag-to-compare interaction
+- **Background:** graph-paper grid with seeded star dots (CSS only, no JS)
+- On mobile (≤840px): sidebar moves above the content, TOC becomes a wrapping chip strip
+
+## Consistency rules
+
+- Always use `layout: astro-workflow` — never `layout: post`
+- Back link always points to `/astrophotography/`, not `/`
+- All section headings are `##` (H2) — never H3 as the top-level section
+- Sub-steps within WBPP are `###` (H3)
+- The `---` horizontal rule separates major sections
+- Next Steps is always a task checklist `- [ ]`
+- Results Summary always uses the three-row table format shown above

--- a/_layouts/astro-workflow.html
+++ b/_layouts/astro-workflow.html
@@ -1,0 +1,451 @@
+---
+layout: default
+---
+
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&display=swap" />
+
+<div class="nb-wrap">
+
+  <!-- Graph-paper / starfield background -->
+  <div class="nb-grid-bg" aria-hidden="true"></div>
+
+  <!-- ── TOP HEADER BAR ── -->
+  <header class="nb-topbar">
+    <span class="nb-topbar-diamond">◆</span>
+    <span class="nb-topbar-title">Field Notes</span>
+    <span>{{ page.date | date: "%-d %b %Y" }}</span>
+    {% if page.target %}<span>{{ page.target }}</span>{% endif %}
+    <div class="nb-topbar-spacer"></div>
+    {% if page.capture and page.capture.location %}<span>{{ page.capture.location }}</span>{% endif %}
+  </header>
+
+  <!-- ── HERO ── -->
+  <section class="nb-hero" data-sec="hero">
+    <div class="nb-hero-grid">
+      <div class="nb-hero-left">
+        <div class="nb-stamp">Entry · Deep-Sky Logbook</div>
+        <h1 class="nb-h1">{{ page.title }}</h1>
+        {% if page.description %}
+        <p class="nb-subtitle">{{ page.description }}</p>
+        {% endif %}
+
+        <!-- Field-data card -->
+        <div class="nb-field-card">
+          {% if page.target %}
+          <div class="nb-field-item">
+            <div class="nb-field-label">Target</div>
+            <div class="nb-field-value">{{ page.target }}</div>
+          </div>
+          {% endif %}
+          {% if page.object_type %}
+          <div class="nb-field-item">
+            <div class="nb-field-label">Type</div>
+            <div class="nb-field-value">{{ page.object_type }}</div>
+          </div>
+          {% endif %}
+          {% if page.constellation %}
+          <div class="nb-field-item">
+            <div class="nb-field-label">Constellation</div>
+            <div class="nb-field-value">{{ page.constellation }}</div>
+          </div>
+          {% endif %}
+          {% if page.capture and page.capture.date %}
+          <div class="nb-field-item">
+            <div class="nb-field-label">Dates</div>
+            <div class="nb-field-value">{{ page.capture.date }}</div>
+          </div>
+          {% endif %}
+          {% if page.capture and page.capture.integration %}
+          <div class="nb-field-item">
+            <div class="nb-field-label">Integration</div>
+            <div class="nb-field-value">{{ page.capture.integration }}</div>
+          </div>
+          {% endif %}
+          {% if page.capture and page.capture.location %}
+          <div class="nb-field-item">
+            <div class="nb-field-label">Location</div>
+            <div class="nb-field-value">{{ page.capture.location }}</div>
+          </div>
+          {% endif %}
+        </div>
+
+        <!-- Badges -->
+        {% if page.tags %}
+        <div class="nb-badges">
+          {% assign accent_cycle = "a1,a2,a3,a1,a2,a3,a1,a2" | split: "," %}
+          {% for tag in page.tags %}
+          <span class="nb-badge nb-badge--{{ accent_cycle[forloop.index0] }}">#{{ tag }}</span>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+
+      <!-- Margin note -->
+      <aside class="nb-marginalia">
+        <div class="nb-marginalia-label">// margin notes</div>
+        {% if page.margin_note %}
+        <p class="nb-marginalia-quote">"{{ page.margin_note }}"</p>
+        {% else %}
+        <p class="nb-marginalia-quote">"The sky doesn't care about your schedule. You learn to work around it."</p>
+        {% endif %}
+        {% if page.margin_note_date %}<div class="nb-marginalia-attr">— {{ page.margin_note_date }}</div>{% endif %}
+      </aside>
+    </div>
+  </section>
+
+  <!-- ── HERO IMAGE ── -->
+  {% if page.hero_image %}
+  <section class="nb-hero-image-wrap">
+    <div class="nb-image-frame">
+      <div class="nb-crosshairs" aria-hidden="true"></div>
+      <img src="{{ page.hero_image | relative_url }}" alt="{{ page.title }}" class="nb-hero-img" />
+      <div class="nb-image-caption">
+        <span>{{ page.hero_image_caption | default: "Final processed image" }}</span>
+        <span class="nb-image-caption-right">plate-solved · CC-BY-NC 4.0</span>
+      </div>
+    </div>
+    <div class="nb-image-tabs" id="nb-image-tabs">
+      <button class="nb-tab nb-tab--active" data-variant="final">Final</button>
+      <button class="nb-tab" data-variant="starless">Starless</button>
+      <button class="nb-tab" data-variant="annotated">Annotated</button>
+      <button class="nb-tab" data-variant="linear">Linear stretch</button>
+    </div>
+    <div class="nb-image-actions">
+      <div class="nb-image-links">
+        <a class="nb-image-link" href="{{ page.hero_image | relative_url }}" target="_blank">↗ Fullscreen</a>
+        {% if page.download_url %}<a class="nb-image-link" href="{{ page.download_url | relative_url }}">↓ Download</a>{% endif %}
+      </div>
+      <div class="nb-image-copy">© {{ page.date | date: "%Y" }}</div>
+    </div>
+  </section>
+  {% else %}
+  <!-- Deep-space SVG placeholder when no real image is provided -->
+  <section class="nb-hero-image-wrap">
+    <div class="nb-image-frame">
+      <div class="nb-crosshairs" aria-hidden="true"></div>
+      <div class="nb-hero-placeholder" id="nb-hero-placeholder"></div>
+      <div class="nb-image-caption">
+        <span>FITS · OSC · debayered VNG</span>
+        <span class="nb-image-caption-right">plate-solved · CC-BY-NC 4.0</span>
+      </div>
+    </div>
+    <div class="nb-image-actions">
+      <div></div>
+      <div class="nb-image-copy">© {{ page.date | date: "%Y" }}</div>
+    </div>
+  </section>
+  {% endif %}
+
+  <!-- ── BODY GRID ── -->
+  <div class="nb-body">
+
+    <!-- Sidebar -->
+    <aside class="nb-sidebar" id="nb-sidebar">
+
+      <!-- TOC -->
+      <div class="nb-stamp nb-stamp--sidebar">Table of Contents</div>
+      <ol class="nb-toc-list" id="nb-toc-list"></ol>
+
+      <!-- Quick Stats from front matter -->
+      {% if page.capture %}
+      <div class="nb-stamp nb-stamp--sidebar nb-stamp--mt">Quick Stats</div>
+      <div class="nb-quick-stats">
+        {% if page.capture.frames %}<div class="nb-stat-row"><span class="nb-stat-key">SUBS</span><span class="nb-stat-val">{{ page.capture.frames }}</span></div>{% endif %}
+        {% if page.capture.exposure %}<div class="nb-stat-row"><span class="nb-stat-key">EXP</span><span class="nb-stat-val">{{ page.capture.exposure }}</span></div>{% endif %}
+        {% if page.capture.integration %}<div class="nb-stat-row"><span class="nb-stat-key">TOTAL</span><span class="nb-stat-val">{{ page.capture.integration }}</span></div>{% endif %}
+        {% if page.capture.gain %}<div class="nb-stat-row"><span class="nb-stat-key">GAIN</span><span class="nb-stat-val">{{ page.capture.gain }}</span></div>{% endif %}
+        {% if page.capture.bortle %}<div class="nb-stat-row"><span class="nb-stat-key">BORTLE</span><span class="nb-stat-val">{{ page.capture.bortle }}</span></div>{% endif %}
+      </div>
+      {% endif %}
+
+      <!-- Gear card -->
+      {% if page.gear %}
+      <div class="nb-stamp nb-stamp--sidebar nb-stamp--mt">Gear · The Bench</div>
+      <div class="nb-gear-card">
+        {% assign gear_items = "" | split: "" %}
+        {% if page.gear.telescope %}
+        <div class="nb-gear-row">
+          <span class="nb-gear-num">01</span>
+          <div class="nb-gear-detail">
+            <div class="nb-gear-sublabel">Telescope</div>
+            <div class="nb-gear-name">{{ page.gear.telescope }}</div>
+          </div>
+        </div>
+        {% endif %}
+        {% if page.gear.camera %}
+        <div class="nb-gear-row">
+          <span class="nb-gear-num">02</span>
+          <div class="nb-gear-detail">
+            <div class="nb-gear-sublabel">Camera</div>
+            <div class="nb-gear-name">{{ page.gear.camera }}</div>
+          </div>
+        </div>
+        {% endif %}
+        {% if page.gear.mount %}
+        <div class="nb-gear-row">
+          <span class="nb-gear-num">03</span>
+          <div class="nb-gear-detail">
+            <div class="nb-gear-sublabel">Mount</div>
+            <div class="nb-gear-name">{{ page.gear.mount }}</div>
+          </div>
+        </div>
+        {% endif %}
+        {% if page.gear.filter %}
+        <div class="nb-gear-row">
+          <span class="nb-gear-num">04</span>
+          <div class="nb-gear-detail">
+            <div class="nb-gear-sublabel">Filter</div>
+            <div class="nb-gear-name">{{ page.gear.filter }}</div>
+          </div>
+        </div>
+        {% endif %}
+        {% if page.gear.software %}
+        <div class="nb-gear-row nb-gear-row--last">
+          <span class="nb-gear-num">05</span>
+          <div class="nb-gear-detail">
+            <div class="nb-gear-sublabel">Software</div>
+            <div class="nb-gear-name">{{ page.gear.software }}</div>
+          </div>
+        </div>
+        {% endif %}
+      </div>
+      {% endif %}
+
+    </aside>
+
+    <!-- Main content column -->
+    <main class="nb-main">
+
+      <!-- Inject front-matter acquisition table if present in page data -->
+      {% if page.acquisition_table %}
+      <section class="nb-section" data-sec="acquisition">
+        <div class="nb-sec-header">
+          <span class="nb-sec-num">§ 01</span>
+          <h2 class="nb-sec-title">Acquisition log</h2>
+          <span class="nb-sec-sub">Per-filter capture summary</span>
+        </div>
+        <table class="nb-table">
+          <thead>
+            <tr>
+              <th>Filter</th><th>Subs</th><th>Exposure</th><th>Gain</th><th>Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in page.acquisition_table %}
+            <tr>
+              <td><span class="nb-acq-dot">●</span>{{ row.filter }}</td>
+              <td>{{ row.subs }}</td>
+              <td>{{ row.exposure }}</td>
+              <td>{{ row.gain }}</td>
+              <td class="nb-acq-total">{{ row.total }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </section>
+      {% endif %}
+
+      <!-- Post markdown content -->
+      <div class="nb-prose" id="nb-prose">
+        {{ content }}
+      </div>
+
+      <!-- Before/After slider — only rendered if page has before/after images -->
+      {% if page.before_image and page.after_image %}
+      <section class="nb-section" data-sec="compare">
+        <div class="nb-sec-header">
+          <span class="nb-sec-num">§</span>
+          <h2 class="nb-sec-title">Before / after</h2>
+          <span class="nb-sec-sub">Drag the divider — raw stack vs. final</span>
+        </div>
+        <div class="nb-ba-container" id="nb-ba">
+          <div class="nb-ba-after"><img src="{{ page.after_image | relative_url }}" alt="Final" /></div>
+          <div class="nb-ba-before" id="nb-ba-before"><img src="{{ page.before_image | relative_url }}" alt="Raw stack" /></div>
+          <div class="nb-ba-label nb-ba-label--left">Raw stack</div>
+          <div class="nb-ba-label nb-ba-label--right">Final</div>
+          <div class="nb-ba-divider" id="nb-ba-divider">
+            <div class="nb-ba-handle">‹ ›</div>
+          </div>
+        </div>
+        <div class="nb-ba-stages">
+          <div class="nb-ba-stage nb-ba-stage--ha">
+            <div class="nb-stamp">Stage A · Raw stack</div>
+            <div class="nb-ba-stage-desc">Linear · WBPP output · no cosmetics</div>
+          </div>
+          <div class="nb-ba-stage nb-ba-stage--blue">
+            <div class="nb-stamp">Stage B · Linear stretch</div>
+            <div class="nb-ba-stage-desc">STF auto-stretch preview · BXT applied</div>
+          </div>
+          <div class="nb-ba-stage nb-ba-stage--teal">
+            <div class="nb-stamp">Stage C · Final</div>
+            <div class="nb-ba-stage-desc">Non-linear · HDR core · stars recombined</div>
+          </div>
+        </div>
+      </section>
+      {% endif %}
+
+      <!-- Footer -->
+      <footer class="nb-footer">
+        <span>End of entry</span>
+        <span class="nb-footer-date">{{ page.date | date: "%b %-d, %Y" }}</span>
+        <span>archived · cc-by-nc 4.0</span>
+      </footer>
+
+    </main>
+  </div>
+</div>
+
+<button class="to-top-button" id="to-top-button" type="button" aria-label="Back to top" title="Back to top">↑</button>
+
+<script>
+(function() {
+  // ── SCROLL-SPY TOC ──────────────────────────────────────────────────
+  const tocList = document.getElementById('nb-toc-list');
+  const main = document.getElementById('nb-prose');
+  const body = document.querySelector('.nb-main');
+
+  function buildToc() {
+    if (!tocList || !main) return;
+    const headings = main.querySelectorAll('h2, h3');
+    if (!headings.length) return;
+
+    // Also include data-sec sections outside prose
+    const allSecs = Array.from(document.querySelectorAll('[data-sec]'))
+      .filter(el => !el.closest('.nb-hero'));
+
+    let items = [];
+    headings.forEach((h, i) => {
+      if (!h.id) h.id = 'nb-h-' + i;
+      items.push({ el: h, label: h.textContent.trim(), level: h.tagName });
+    });
+
+    let counter = 1;
+    items.forEach(({ el, label, level }) => {
+      const li = document.createElement('li');
+      li.className = 'nb-toc-item';
+      const btn = document.createElement('button');
+      btn.className = 'nb-toc-btn' + (level === 'H3' ? ' nb-toc-btn--h3' : '');
+      btn.innerHTML = `<span class="nb-toc-num">${String(counter++).padStart(2,'0')}</span><span class="nb-toc-label">${label}</span>`;
+      btn.addEventListener('click', () => {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+      li.appendChild(btn);
+      tocList.appendChild(li);
+    });
+
+    // Scroll-spy
+    const obs = new IntersectionObserver((entries) => {
+      entries.forEach(e => {
+        const id = e.target.id;
+        const btn = tocList.querySelector(`[data-target="${id}"]`);
+        if (!btn) return;
+        if (e.isIntersecting) {
+          tocList.querySelectorAll('.nb-toc-btn').forEach(b => b.classList.remove('nb-toc-btn--active'));
+          btn.classList.add('nb-toc-btn--active');
+        }
+      });
+    }, { rootMargin: '-20% 0px -70% 0px' });
+
+    items.forEach(({ el }, i) => {
+      tocList.querySelectorAll('.nb-toc-btn')[i].setAttribute('data-target', el.id);
+      obs.observe(el);
+    });
+  }
+
+  // ── BEFORE/AFTER SLIDER ─────────────────────────────────────────────
+  function initBeforeAfter() {
+    const track = document.getElementById('nb-ba');
+    if (!track) return;
+    const before = document.getElementById('nb-ba-before');
+    const divider = document.getElementById('nb-ba-divider');
+    let dragging = false;
+
+    function setPos(clientX) {
+      const r = track.getBoundingClientRect();
+      const pct = Math.max(0, Math.min(100, ((clientX - r.left) / r.width) * 100));
+      before.style.clipPath = `inset(0 ${100 - pct}% 0 0)`;
+      divider.style.left = pct + '%';
+    }
+
+    divider.addEventListener('mousedown', e => { dragging = true; e.preventDefault(); });
+    track.addEventListener('mousedown', e => { dragging = true; setPos(e.clientX); });
+    window.addEventListener('mousemove', e => { if (dragging) setPos(e.clientX); });
+    window.addEventListener('mouseup', () => { dragging = false; });
+    divider.addEventListener('touchstart', e => { dragging = true; }, { passive: true });
+    window.addEventListener('touchmove', e => { if (dragging) setPos(e.touches[0].clientX); }, { passive: true });
+    window.addEventListener('touchend', () => { dragging = false; });
+
+    setPos(track.getBoundingClientRect().left + track.getBoundingClientRect().width * 0.5);
+  }
+
+  // ── TO-TOP BUTTON ───────────────────────────────────────────────────
+  function initToTop() {
+    const btn = document.getElementById('to-top-button');
+    if (!btn) return;
+    window.addEventListener('scroll', () => {
+      btn.classList.toggle('is-visible', window.scrollY > 400);
+    }, { passive: true });
+    btn.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
+  }
+
+  // ── DEEP-SPACE SVG PLACEHOLDER ──────────────────────────────────────
+  function renderPlaceholder() {
+    const el = document.getElementById('nb-hero-placeholder');
+    if (!el) return;
+    el.innerHTML = `<svg viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice"
+      style="width:100%;height:100%;display:block;">
+      <defs>
+        <radialGradient id="nb-core" cx="50%" cy="48%" r="22%">
+          <stop offset="0%" stop-color="#fff6e8" stop-opacity="1"/>
+          <stop offset="18%" stop-color="#ffd9a0" stop-opacity="0.95"/>
+          <stop offset="45%" stop-color="#ff9560" stop-opacity="0.7"/>
+          <stop offset="75%" stop-color="#c4485a" stop-opacity="0.35"/>
+          <stop offset="100%" stop-color="#3a1530" stop-opacity="0"/>
+        </radialGradient>
+        <radialGradient id="nb-ha" cx="50%" cy="50%" r="62%">
+          <stop offset="0%" stop-color="#e85a4f" stop-opacity="0"/>
+          <stop offset="35%" stop-color="#c84a55" stop-opacity="0.55"/>
+          <stop offset="65%" stop-color="#8a3360" stop-opacity="0.35"/>
+          <stop offset="100%" stop-color="#1a0a20" stop-opacity="0"/>
+        </radialGradient>
+        <radialGradient id="nb-oiii" cx="62%" cy="28%" r="22%">
+          <stop offset="0%" stop-color="#9ee9e5" stop-opacity="0.85"/>
+          <stop offset="50%" stop-color="#5ec5c1" stop-opacity="0.45"/>
+          <stop offset="100%" stop-color="#1f4a55" stop-opacity="0"/>
+        </radialGradient>
+        <radialGradient id="nb-dust" cx="36%" cy="62%" r="26%">
+          <stop offset="0%" stop-color="#070310" stop-opacity="0.85"/>
+          <stop offset="60%" stop-color="#0a0414" stop-opacity="0.3"/>
+          <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+        </radialGradient>
+        <radialGradient id="nb-sky" cx="50%" cy="50%" r="80%">
+          <stop offset="0%" stop-color="#0a1226"/>
+          <stop offset="60%" stop-color="#06091a"/>
+          <stop offset="100%" stop-color="#02030a"/>
+        </radialGradient>
+        <filter id="nb-blur"><feGaussianBlur stdDeviation="0.6"/></filter>
+      </defs>
+      <rect width="1600" height="900" fill="url(#nb-sky)"/>
+      <ellipse cx="800" cy="450" rx="780" ry="430" fill="url(#nb-ha)" opacity="0.85"/>
+      <ellipse cx="990" cy="260" rx="280" ry="180" fill="url(#nb-oiii)"/>
+      <ellipse cx="580" cy="560" rx="380" ry="240" fill="url(#nb-dust)"/>
+      <ellipse cx="800" cy="432" rx="320" ry="220" fill="url(#nb-core)"/>
+      <circle cx="792" cy="425" r="7.5" fill="#fff6e8" opacity="0.35" filter="url(#nb-blur)"/>
+      <circle cx="792" cy="425" r="3.4" fill="#fff"/>
+      <circle cx="810" cy="431" r="6" fill="#fff6e8" opacity="0.35" filter="url(#nb-blur)"/>
+      <circle cx="810" cy="431" r="2.8" fill="#fff"/>
+      <circle cx="806" cy="418" r="5.3" fill="#fff6e8" opacity="0.35" filter="url(#nb-blur)"/>
+      <circle cx="806" cy="418" r="2.4" fill="#fff"/>
+    </svg>`;
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    buildToc();
+    initBeforeAfter();
+    initToTop();
+    renderPlaceholder();
+  });
+})();
+</script>

--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -1079,3 +1079,899 @@ body.modal-open {
     bottom: 72px;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════
+   GEAR PANEL  (astro-workflow layout sidebar)
+   ═══════════════════════════════════════════════════════════ */
+
+.gear-panel-inner {
+  display: grid;
+  gap: 18px;
+}
+
+.gear-section {
+  display: grid;
+  gap: 3px;
+}
+
+.gear-section-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-faint);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.gear-section-label--capture {
+  margin-top: 8px;
+  padding-top: 16px;
+  border-top: 1px solid var(--rule);
+}
+
+.gear-value {
+  font-size: 14px;
+  color: var(--ink-soft);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.gear-stat-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  padding: 3px 0;
+}
+
+.gear-stat-key {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-faint);
+  flex-shrink: 0;
+}
+
+.gear-stat-val {
+  font-size: 13px;
+  color: var(--ink-soft);
+  text-align: right;
+}
+
+@media (max-width: 1080px) {
+  .gear-panel {
+    order: -1;
+  }
+
+  .gear-panel-inner {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 14px 24px;
+    border-left: none;
+    border-bottom: 1px solid var(--rule);
+    padding: 0 0 18px;
+  }
+
+  .gear-section-label--capture {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: none;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════
+   OBSERVATORY NOTEBOOK LAYOUT  (astro-workflow)
+   Dark theme, graph-paper bg, mono caps, gear sidebar.
+   All .nb-* classes are scoped to this layout only.
+   ═══════════════════════════════════════════════════════════ */
+
+/* ── Tokens ── */
+.nb-wrap {
+  --nb-bg:       #070a14;
+  --nb-ink:      #d8dde8;
+  --nb-ink-soft: #b8c2d4;
+  --nb-ink-faint:rgba(180,196,224,0.55);
+  --nb-rule:     rgba(180,196,224,0.12);
+  --nb-rule-dash:rgba(180,196,224,0.18);
+  --nb-card-bg:  rgba(10,14,26,0.6);
+  --nb-a1:       #e85a4f;
+  --nb-a2:       #5ec5c1;
+  --nb-a3:       #8aa9ff;
+  --nb-mono:     'JetBrains Mono', ui-monospace, monospace;
+  --nb-serif:    'Source Serif 4', 'Source Serif Pro', Georgia, serif;
+
+  position: relative;
+  background: var(--nb-bg);
+  color: var(--nb-ink);
+  font-family: var(--nb-serif);
+  min-height: 100vh;
+}
+
+/* ── Graph-paper grid background ── */
+.nb-grid-bg {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image:
+    radial-gradient(rgba(255,255,255,0.65) 0.5px, transparent 0.5px),
+    linear-gradient(rgba(255,255,255,0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.025) 1px, transparent 1px);
+  background-size: 180px 180px, 24px 24px, 24px 24px;
+  opacity: 0.55;
+  mask-image: linear-gradient(180deg, transparent 0, #000 160px, #000 calc(100% - 160px), transparent 100%);
+}
+
+/* ── Top header bar ── */
+.nb-topbar {
+  position: sticky;
+  top: var(--nav-h);
+  z-index: 10;
+  background: rgba(7,10,20,0.92);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--nb-rule);
+  padding: 13px 56px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  font-family: var(--nb-mono);
+  font-size: 11px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: var(--nb-ink-faint);
+}
+
+.nb-topbar-diamond { color: var(--nb-a2); }
+.nb-topbar-title   { color: var(--nb-ink); }
+.nb-topbar-spacer  { flex: 1; }
+
+/* ── Hero ── */
+.nb-hero {
+  position: relative;
+  z-index: 1;
+  padding: 52px 56px 28px;
+}
+
+.nb-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0,1fr) 220px;
+  gap: 40px;
+  align-items: end;
+}
+
+.nb-h1 {
+  font-family: var(--nb-mono);
+  font-weight: 500;
+  font-size: clamp(32px, 4vw, 52px);
+  line-height: 1.05;
+  letter-spacing: -0.5px;
+  margin: 0 0 16px;
+  color: #f1f3f8;
+}
+
+.nb-subtitle {
+  font-family: var(--nb-serif);
+  font-size: 19px;
+  line-height: 1.5;
+  color: #b8c2d4;
+  margin: 0 0 26px;
+  max-width: 680px;
+}
+
+/* ── Mono stamp label ── */
+.nb-stamp {
+  font-family: var(--nb-mono);
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--nb-ink-faint);
+  margin-bottom: 12px;
+}
+
+.nb-stamp--sidebar { margin-bottom: 10px; }
+.nb-stamp--mt      { margin-top: 26px; }
+
+/* ── Field-data card ── */
+.nb-field-card {
+  border: 1px solid var(--nb-rule);
+  padding: 18px 22px;
+  background: var(--nb-card-bg);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px 28px;
+  font-family: var(--nb-mono);
+  font-size: 12px;
+  margin-bottom: 18px;
+}
+
+.nb-field-label {
+  font-size: 9px;
+  letter-spacing: 1.8px;
+  color: var(--nb-ink-faint);
+  text-transform: uppercase;
+  margin-bottom: 3px;
+}
+
+.nb-field-value {
+  color: #e7ecf6;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Badges ── */
+.nb-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.nb-badge {
+  font-family: var(--nb-mono);
+  font-size: 10px;
+  letter-spacing: 1.4px;
+  padding: 4px 9px;
+  border: 1px solid var(--nb-rule);
+  text-transform: uppercase;
+}
+
+.nb-badge--a1 { color: var(--nb-a1); }
+.nb-badge--a2 { color: var(--nb-a2); }
+.nb-badge--a3 { color: var(--nb-a3); }
+
+/* ── Marginalia ── */
+.nb-marginalia {
+  border-left: 1px dashed var(--nb-rule-dash);
+  padding-left: 22px;
+  font-family: var(--nb-mono);
+  font-size: 11px;
+  line-height: 1.7;
+  color: var(--nb-ink-faint);
+}
+
+.nb-marginalia-label { color: var(--nb-a2); margin-bottom: 8px; }
+
+.nb-marginalia-quote {
+  margin: 0 0 10px;
+  color: #c8d0e0;
+  font-style: italic;
+  font-family: var(--nb-serif);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.nb-marginalia-attr { font-size: 11px; }
+
+/* ── Hero image frame ── */
+.nb-hero-image-wrap {
+  position: relative;
+  z-index: 1;
+  padding: 0 56px 28px;
+}
+
+.nb-image-frame {
+  position: relative;
+  border: 1px solid var(--nb-rule);
+  background: #000;
+  overflow: hidden;
+}
+
+.nb-hero-img {
+  width: 100%;
+  display: block;
+  aspect-ratio: 16/9;
+  object-fit: cover;
+}
+
+.nb-hero-placeholder {
+  width: 100%;
+  aspect-ratio: 16/9;
+  background: #05070d;
+}
+
+/* Crosshair ticks */
+.nb-crosshairs {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.nb-crosshairs::before,
+.nb-crosshairs::after {
+  content: '';
+  position: absolute;
+  background: var(--nb-a2);
+}
+
+/* Corner bracket marks via box-shadow */
+.nb-image-frame::before,
+.nb-image-frame::after {
+  content: '';
+  position: absolute;
+  z-index: 3;
+  width: 16px;
+  height: 16px;
+  pointer-events: none;
+}
+
+.nb-image-frame::before {
+  top: 8px;
+  left: 8px;
+  border-top: 1.5px solid var(--nb-a2);
+  border-left: 1.5px solid var(--nb-a2);
+}
+
+.nb-image-frame::after {
+  bottom: 36px;
+  right: 8px;
+  border-bottom: 1.5px solid var(--nb-a2);
+  border-right: 1.5px solid var(--nb-a2);
+}
+
+.nb-image-caption {
+  padding: 9px 13px;
+  border-top: 1px solid var(--nb-rule);
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--nb-mono);
+  font-size: 10px;
+  letter-spacing: 1.4px;
+  color: var(--nb-ink-faint);
+  text-transform: uppercase;
+}
+
+.nb-image-caption-right { color: var(--nb-a3); }
+
+.nb-image-tabs {
+  display: flex;
+  gap: 1px;
+  background: rgba(255,255,255,0.05);
+  padding: 1px;
+  margin-top: 14px;
+}
+
+.nb-tab {
+  flex: 1;
+  padding: 9px 12px;
+  border: 0;
+  cursor: pointer;
+  background: rgba(8,12,22,0.85);
+  color: #cfd6e4;
+  font-family: var(--nb-mono);
+  font-size: 11px;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  transition: background 0.15s, color 0.15s;
+}
+
+.nb-tab:hover { background: rgba(138,169,255,0.12); color: var(--nb-a3); }
+
+.nb-tab--active {
+  background: var(--nb-a3);
+  color: #0a0e1a;
+  font-weight: 600;
+}
+
+.nb-image-actions {
+  margin-top: 11px;
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  font-family: var(--nb-mono);
+  font-size: 11px;
+  letter-spacing: 1.2px;
+  color: var(--nb-ink-faint);
+}
+
+.nb-image-links { display: flex; gap: 20px; }
+
+.nb-image-link {
+  color: #d8dde8;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  text-decoration-color: var(--nb-rule-dash);
+}
+
+.nb-image-link:hover { color: var(--nb-a3); text-decoration-color: var(--nb-a3); }
+.nb-image-copy { color: var(--nb-ink-faint); }
+
+/* ── Body grid: sidebar + main ── */
+.nb-body {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 240px minmax(0,1fr);
+  gap: 52px;
+  padding: 28px 56px 80px;
+}
+
+/* ── Sidebar ── */
+.nb-sidebar {
+  position: sticky;
+  top: calc(var(--nav-h) + 48px);
+  align-self: start;
+  max-height: calc(100vh - var(--nav-h) - 80px);
+  overflow-y: auto;
+  padding-right: 6px;
+  border-right: 1px dashed var(--nb-rule-dash);
+  font-family: var(--nb-mono);
+  scrollbar-width: thin;
+  scrollbar-color: var(--nb-rule) transparent;
+}
+
+/* TOC list */
+.nb-toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nb-toc-item { margin-bottom: 2px; }
+
+.nb-toc-btn {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding: 6px 8px 6px 10px;
+  font-family: var(--nb-mono);
+  font-size: 12px;
+  color: #a4adbe;
+  border-left: 2px solid transparent;
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.nb-toc-btn:hover { color: #d8dde8; }
+
+.nb-toc-btn--active {
+  color: var(--nb-a2);
+  border-left-color: var(--nb-a2);
+}
+
+.nb-toc-btn--h3 { padding-left: 24px; font-size: 11px; }
+
+.nb-toc-num {
+  opacity: 0.5;
+  font-variant-numeric: tabular-nums;
+  min-width: 22px;
+}
+
+.nb-toc-label {
+  font-family: var(--nb-serif);
+  font-size: 14px;
+  line-height: 1.3;
+}
+
+/* Quick stats */
+.nb-quick-stats {
+  font-size: 11px;
+  line-height: 1.85;
+  color: #bcc4d4;
+}
+
+.nb-stat-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.nb-stat-key  { color: var(--nb-ink-faint); }
+.nb-stat-val  { font-variant-numeric: tabular-nums; }
+
+/* Gear card */
+.nb-gear-card {
+  border: 1px solid var(--nb-rule);
+  background: rgba(10,14,26,0.55);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.nb-gear-row {
+  display: grid;
+  grid-template-columns: 22px 1fr;
+  gap: 8px;
+  padding: 9px 11px;
+  border-bottom: 1px dashed var(--nb-rule);
+}
+
+.nb-gear-row--last { border-bottom: none; }
+
+.nb-gear-num { color: var(--nb-a2); font-variant-numeric: tabular-nums; }
+
+.nb-gear-sublabel {
+  font-size: 9px;
+  letter-spacing: 1.6px;
+  color: var(--nb-ink-faint);
+  text-transform: uppercase;
+}
+
+.nb-gear-name {
+  font-family: var(--nb-serif);
+  font-size: 14px;
+  color: #e7ecf6;
+  line-height: 1.3;
+  margin-top: 2px;
+}
+
+.nb-gear-sub { color: var(--nb-ink-faint); font-size: 10px; margin-top: 2px; }
+
+/* ── Main column ── */
+.nb-main { min-width: 0; }
+
+/* ── Section header ── */
+.nb-sec-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 14px;
+  align-items: baseline;
+  border-bottom: 1px solid var(--nb-rule);
+  padding-bottom: 11px;
+  margin-bottom: 18px;
+}
+
+.nb-sec-num {
+  font-family: var(--nb-mono);
+  font-size: 11px;
+  color: var(--nb-a2);
+  letter-spacing: 2px;
+}
+
+.nb-sec-title {
+  margin: 0;
+  font-family: var(--nb-mono);
+  font-weight: 500;
+  font-size: 20px;
+  letter-spacing: -0.3px;
+  color: #f1f3f8;
+}
+
+.nb-sec-sub {
+  font-family: var(--nb-serif);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--nb-ink-faint);
+}
+
+.nb-section { margin-bottom: 60px; }
+
+/* ── Acquisition table ── */
+.nb-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--nb-mono);
+  font-size: 12px;
+}
+
+.nb-table th {
+  text-align: left;
+  padding: 7px 11px 9px;
+  border-bottom: 1px solid var(--nb-rule);
+  font-size: 10px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: var(--nb-ink-faint);
+  font-weight: 500;
+}
+
+.nb-table td {
+  padding: 10px 11px;
+  border-bottom: 1px solid var(--nb-rule);
+  font-variant-numeric: tabular-nums;
+}
+
+.nb-acq-dot { color: var(--nb-a1); margin-right: 8px; }
+.nb-acq-total { color: var(--nb-a2); }
+
+/* ── Prose — markdown content ── */
+.nb-prose {
+  font-family: var(--nb-serif);
+  font-size: 17px;
+  line-height: 1.72;
+  color: #c8d0e0;
+  max-width: 720px;
+}
+
+.nb-prose h2 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  align-items: baseline;
+  border-bottom: 1px solid var(--nb-rule);
+  padding-bottom: 10px;
+  margin: 56px 0 18px;
+  font-family: var(--nb-mono);
+  font-weight: 500;
+  font-size: 20px;
+  letter-spacing: -0.3px;
+  color: #f1f3f8;
+}
+
+.nb-prose h2::before {
+  content: '§';
+  font-size: 11px;
+  color: var(--nb-a2);
+  letter-spacing: 2px;
+  align-self: center;
+}
+
+.nb-prose h3 {
+  font-family: var(--nb-mono);
+  font-size: 14px;
+  letter-spacing: 0.5px;
+  color: #e7ecf6;
+  margin: 32px 0 10px;
+  text-transform: uppercase;
+  letter-spacing: 1.4px;
+}
+
+.nb-prose p { margin: 0 0 18px; }
+
+.nb-prose strong { color: #e7ecf6; font-weight: 600; }
+
+.nb-prose a { color: var(--nb-a3); text-decoration: underline; text-underline-offset: 3px; }
+
+.nb-prose hr {
+  border: none;
+  border-top: 1px solid var(--nb-rule);
+  margin: 48px 0;
+}
+
+.nb-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--nb-mono);
+  font-size: 12px;
+  margin: 22px 0;
+}
+
+.nb-prose table th {
+  text-align: left;
+  padding: 6px 10px 8px;
+  border-bottom: 1px solid var(--nb-rule);
+  font-size: 10px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: var(--nb-ink-faint);
+  font-weight: 500;
+}
+
+.nb-prose table td {
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--nb-rule);
+  font-variant-numeric: tabular-nums;
+  color: #cfd6e4;
+}
+
+.nb-prose pre,
+.nb-prose code {
+  font-family: var(--nb-mono);
+  font-size: 12px;
+  color: #bcc4d4;
+}
+
+.nb-prose pre {
+  margin: 20px 0;
+  padding: 13px 16px;
+  background: rgba(8,12,22,0.85);
+  border: 1px solid var(--nb-rule);
+  line-height: 1.65;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.nb-prose code {
+  background: rgba(8,12,22,0.6);
+  padding: 1px 5px;
+  border: 1px solid var(--nb-rule);
+}
+
+.nb-prose pre code {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.nb-prose ol,
+.nb-prose ul {
+  margin: 0 0 18px;
+  padding-left: 24px;
+}
+
+.nb-prose li { margin-bottom: 6px; }
+
+/* Callout blockquote — maps to > in markdown */
+.nb-prose blockquote {
+  margin: 22px 0;
+  padding: 14px 18px;
+  border-left: 2px solid var(--nb-a3);
+  background: rgba(10,14,26,0.55);
+  font-family: var(--nb-serif);
+  font-size: 16px;
+  line-height: 1.6;
+  color: #d8dde8;
+}
+
+.nb-prose blockquote p { margin: 0; }
+
+/* ── Before / after slider ── */
+.nb-ba-container {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16/9;
+  overflow: hidden;
+  cursor: ew-resize;
+  user-select: none;
+  border: 1px solid var(--nb-rule);
+}
+
+.nb-ba-after,
+.nb-ba-before {
+  position: absolute;
+  inset: 0;
+}
+
+.nb-ba-after img,
+.nb-ba-before img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.nb-ba-before { clip-path: inset(0 50% 0 0); }
+
+.nb-ba-label {
+  position: absolute;
+  top: 14px;
+  padding: 3px 8px;
+  background: rgba(0,0,0,0.6);
+  color: #cfd6e4;
+  font-size: 11px;
+  letter-spacing: 1.4px;
+  font-family: var(--nb-mono);
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+.nb-ba-label--left  { left: 14px; }
+.nb-ba-label--right { right: 14px; }
+
+.nb-ba-divider {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  background: var(--nb-a3);
+  box-shadow: 0 0 14px var(--nb-a3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.nb-ba-handle {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: rgba(10,14,26,0.85);
+  border: 1.5px solid var(--nb-a3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--nb-a3);
+  font-family: var(--nb-mono);
+  font-size: 13px;
+  margin-left: -16px;
+}
+
+.nb-ba-stages {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 13px;
+  margin-top: 13px;
+  font-family: var(--nb-mono);
+  font-size: 11px;
+  color: var(--nb-ink-faint);
+}
+
+.nb-ba-stage { padding-top: 8px; }
+.nb-ba-stage--ha   { border-top: 2px solid var(--nb-a1); }
+.nb-ba-stage--blue { border-top: 2px solid var(--nb-a3); }
+.nb-ba-stage--teal { border-top: 2px solid var(--nb-a2); }
+
+.nb-ba-stage-desc { color: #cfd6e4; margin-top: 4px; font-size: 11px; }
+
+/* ── Footer ── */
+.nb-footer {
+  border-top: 1px solid var(--nb-rule);
+  margin-top: 56px;
+  padding-top: 22px;
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--nb-mono);
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--nb-ink-faint);
+}
+
+.nb-footer-date { color: var(--nb-a2); }
+
+/* ── Processing timeline (ol.nb-timeline in markdown) ── */
+.nb-prose ol.nb-timeline {
+  list-style: none;
+  margin: 20px 0;
+  padding: 0;
+  position: relative;
+}
+
+.nb-prose ol.nb-timeline::before {
+  content: '';
+  position: absolute;
+  left: 13px;
+  top: 14px;
+  bottom: 14px;
+  width: 1px;
+  background: var(--nb-rule);
+}
+
+/* ── Responsive ── */
+@media (max-width: 1100px) {
+  .nb-body {
+    grid-template-columns: 200px minmax(0,1fr);
+    gap: 36px;
+    padding: 24px 32px 64px;
+  }
+  .nb-hero { padding: 40px 32px 24px; }
+  .nb-hero-image-wrap { padding: 0 32px 24px; }
+  .nb-topbar { padding: 12px 32px; }
+  .nb-field-card { grid-template-columns: repeat(3, 1fr); }
+}
+
+@media (max-width: 840px) {
+  .nb-body {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding: 20px 20px 56px;
+  }
+
+  .nb-sidebar {
+    position: static;
+    max-height: none;
+    border-right: none;
+    border-bottom: 1px dashed var(--nb-rule-dash);
+    padding-right: 0;
+    padding-bottom: 20px;
+    margin-bottom: 8px;
+    overflow: visible;
+  }
+
+  .nb-toc-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px 4px;
+  }
+
+  .nb-toc-num { display: none; }
+
+  .nb-hero { padding: 32px 20px 20px; }
+  .nb-hero-image-wrap { padding: 0 20px 20px; }
+  .nb-topbar { padding: 11px 20px; font-size: 10px; gap: 16px; }
+  .nb-hero-grid { grid-template-columns: 1fr; gap: 24px; }
+  .nb-marginalia { border-left: none; padding-left: 0; border-top: 1px dashed var(--nb-rule-dash); padding-top: 16px; }
+  .nb-field-card { grid-template-columns: repeat(2, 1fr); }
+  .nb-ba-stages { grid-template-columns: 1fr; }
+  .nb-footer { flex-direction: column; gap: 6px; }
+}
+
+@media (max-width: 480px) {
+  .nb-body { padding: 16px 16px 48px; }
+  .nb-hero { padding: 24px 16px 16px; }
+  .nb-hero-image-wrap { padding: 0 16px 16px; }
+  .nb-topbar { padding: 10px 16px; }
+  .nb-field-card { grid-template-columns: 1fr 1fr; }
+  .nb-h1 { font-size: 28px; }
+}


### PR DESCRIPTION
…osts

- New _layouts/astro-workflow.html: dark, mono-caps notebook design with sticky gear sidebar (TOC + quick stats + numbered gear card), graph-paper grid background, crosshair hero image frame, deep-space SVG placeholder, and drag-to-compare before/after slider
- CSS: ~900 lines of .nb-* styles scoped to the notebook layout; responsive at 1100/840/480px; nb-topbar stacks under site nav via --nav-h offset
- Skill: .superpowers/skills/new-astro-post.md documents the full front matter schema, WBPP log parsing rules, and post section structure for consistent astrophotography workflow posts