### PR TITLE
docs: rewrite PixInsight workflow as recipe

### DIFF
--- a/_posts/2026-05-18-horsehead-flame-nebula-wbpp-workflow.md
+++ b/_posts/2026-05-18-horsehead-flame-nebula-wbpp-workflow.md
@@ -37,13 +37,15 @@ capture:
 
 ## Target
 
-The **Horsehead Nebula (Barnard 33)** is a dark absorption nebula silhouetted against the glowing emission of IC 434, a faint sheet of ionized hydrogen stretching south from the bright star Alnitak in Orion's Belt. Immediately to the west, the **Flame Nebula (NGC 2024)** blazes around Alnitak itself, lit by its ultraviolet output. Together they are among the most recognizable nebulae in the winter sky — and among the most punishing to image from a suburban site. The Horsehead's contrast depends entirely on the faint Ha glow behind it, which a broadband LP filter captures only partially.
+The **Horsehead Nebula (Barnard 33)** is a dark absorption nebula silhouetted against IC 434, the faint hydrogen emission sheet south of Alnitak in Orion's Belt. The nearby **Flame Nebula (NGC 2024)** adds bright structure and a difficult glare source from Alnitak.
+
+This workflow is written as a PixInsight recipe: which process to open, what to set, what to inspect, and what output to carry forward. It does not depend on screenshots of the PixInsight dialogs.
 
 ---
 
 ## Acquisition
 
-The Seestar S50 ran across two nights in **EQ mode**, tracking the field with electronic field de-rotation. Alnitak is bright enough to cause blooming artifacts in long exposures; 10-second subs kept this controlled while still accumulating enough integration time to pull the nebulosity out of the Bortle 8 sky background.
+The Seestar S50 ran across two nights in **EQ mode**, tracking the field with electronic field de-rotation. Ten-second subs kept Alnitak under control while accumulating enough signal to pull IC 434 and the Horsehead silhouette out of a Bortle 8 sky.
 
 | Parameter | Value |
 |-----------|-------|
@@ -54,149 +56,269 @@ The Seestar S50 ran across two nights in **EQ mode**, tracking the field with el
 | Mode | CFA / OSC |
 | Calibration frames | None |
 
-No darks, flats, or bias frames were used. WBPP handled internal calibration estimation from the light frames directly.
+No darks, flats, or bias frames were used. WBPP handled the light frames directly, so the later normalization and background extraction steps matter more than they would in a fully calibrated dataset.
 
 ---
 
-## WBPP Run — Step by Step
+## Workflow Overview
 
-### 1. Light Frame Calibration
-
-WBPP opened all 1146 frames as a single group:
-
-```
-Group of 1146 Light frames (1146 active)
-SIZE  : 1080×1920  |  BINNING : 1
-Filter : LP  |  Exposure : 10.00 s
-Color  : CFA  |  Mode : calibration
-```
-
-No calibration masters were attached. The run used internal calibration mode.
-
-### 2. Debayering (Demosaicing)
-
-All 1146 frames debayered from raw Bayer CFA to RGB:
-
-- **Pattern:** Auto (auto-detected)
-- **Method:** VNG (Variable Number of Gradients)
-
-All 1146 frames completed demosaicing successfully.
-
-### 3. Image Measurements
-
-WBPP measured each debayered frame for FWHM, eccentricity, and SNR. These scores feed directly into the per-frame weights used during integration — worse frames receive lower weight rather than being discarded outright.
-
-### 4. Reference Frame Selection
-
-WBPP auto-selected the best reference for star registration:
-
-```
-Best reference: Light_IC 434_10.0s_LP_20260131-192733_d.xisf
-```
-
-Selected from the second night (Jan 31), around 19:27 UTC — likely the best atmospheric stability window of the two-night run.
-
-### 5. Image Registration
-
-Star registration ran against the auto-selected reference. **1138 of 1146 frames registered successfully.** 8 frames failed (0.70% rejection rate).
-
-The 8 failed frames cluster as follows:
-
-- **Jan 30 — 20:53, 21:54, 22:10, 22:11, 22:41** (five failures spread across the first night's early and mid session)
-- **Jan 31 — 19:35, 19:51, 20:59** (three isolated failures on the second night)
-
-At 0.7% the rejection rate is exceptionally low. No single time cluster stands out — these are likely individual frames with momentary tracking glitches or passing clouds rather than a systemic problem.
-
-### 6. Local Normalization
-
-This run used **local normalization**, unlike the M81 session. WBPP generated a local normalization map for each frame before integration:
-
-```
-LN.scale = 270
-LN.rejection = true
-LN.highClippingLevel = 0.85
-LN.referenceRejectionThreshold = 3.00
-```
-
-Local normalization corrects frame-to-frame variation in sky background illumination across the field — particularly useful here because:
-
-1. **No flat frames were used.** Without flats, vignetting and illumination gradients vary subtly between frames as the field rotates in EQ mode. Local normalization compensates for this.
-2. **Two-night dataset.** Atmospheric conditions and sky background brightness differed between Jan 30 and Jan 31. Local normalization aligns each frame's background model before stacking, preventing the two nights from averaging inconsistently.
-3. **Alnitak proximity.** The very bright star at the edge of the field causes a strong local illumination gradient. Local normalization handles this better than global normalization.
-
-### 7. Integration
-
-After local normalization, WBPP integrated the 1138 registered frames using:
-
-- **Rejection method:** Linear Fit Clipping with Local Rejection Normalization
-- **Integration:** SNR-weighted average
-
-A separate sub-stack of 20 frames was also integrated at this stage (visible in the log as a `Group of 20 Light frames`) — likely WBPP's internal preview or best-frames sub-stack for registration quality assessment.
+| Stage | Process / module | Purpose | Output |
+|-------|------------------|---------|--------|
+| Preprocessing | WeightedBatchPreprocessing | Load, measure, register, normalize, and integrate the OSC lights | Linear RGB master |
+| Frame conversion | Debayer | Convert CFA frames to RGB | Debayered registered frames |
+| Frame matching | Local Normalization | Match sky background across two nights | Normalized frames for stacking |
+| Integration | ImageIntegration / DrizzleIntegration | Reject bad pixels and combine the accepted frames | Final linear master |
+| Crop/orientation | FastRotation / DynamicCrop | Correct orientation and remove edge artifacts | Clean linear working frame |
+| Gradient removal | DynamicBackgroundExtraction | Remove light pollution and field gradients | Linear gradient-corrected image |
+| Linear correction | BlurXTerminator, NoiseXTerminator, SCNR | Correct star profiles, reduce noise, neutralize green cast | Cleaner linear image |
+| Starless workflow | StarXTerminator | Separate stars from nebula before stretching | Starless image plus star layer |
+| Stretch | PixelMath, Statistical Stretch | Set a robust blackpoint and stretch midtones | Nonlinear image |
+| Local contrast | LocalHistogramEqualization, HDRMultiscaleTransform | Bring out nebula structure and control Alnitak | Finished nonlinear image |
 
 ---
 
-## Post-Processing — Step by Step
+## Part 1: WBPP Preprocessing Recipe
 
-The post-processing session ran on 2026-05-18 starting at 02:13 UTC — immediately after WBPP completed. The full sequence from the PixInsight project log:
+PixInsight's process interfaces are parameter-driven. The useful mental model is not "follow the log"; it is "configure the process, apply it, inspect the output, then carry that output into the next process."
 
-### 1. Integration (Drizzle stack)
+### 1. Load the Lights in WeightedBatchPreprocessing
 
-A second ImageIntegration run at `02:13` (~9 minutes) produced the final master light. The project contains both a standard-integration and a drizzle-integrated master (`masterLight_…_drizzle_1x.xisf`, 51.6 MB vs 75.6 MB). The drizzle pass upsamples the stack by 1× — useful at the Seestar's modest 250mm focal length to recover detail that would otherwise be lost to pixel scale aliasing.
+**Use:** `Script > Batch Processing > WeightedBatchPreprocessing`
 
-### 2. Rotate and Combine
+**Set:**
 
-At `02:27`, a `FastRotation` was applied — correcting the field orientation from EQ-mode de-rotation to a natural north-up framing. This was followed immediately by `ChannelCombination` (RGB reassembly) and `DynamicCrop` to trim the rotated image edges.
+- Add all 1146 Seestar light frames as one light group.
+- Confirm the image size is `1080x1920`, binning is `1`, exposure is `10.00 s`, and the data is CFA/OSC.
+- Do not attach calibration masters for this run.
 
-### 3. Background Extraction (DBE)
+**Inspect:**
 
-`DynamicBackgroundExtraction` ran at `03:00`. DBE fits a polynomial surface to manually-placed background sample points and subtracts it, eliminating the LP gradient and the vignetting roll-off from Alnitak's proximity. With `derivativeOrder = 2` (second-order polynomial), the correction handles modest gradient curvature without over-fitting to the nebula itself.
+- WBPP should show all 1146 light frames active.
+- The group should be treated as CFA data before debayering.
+- If WBPP splits the frames into unexpected groups, check the filter, exposure, and metadata fields before continuing.
 
-### 4. Linear Deconvolution (BlurXTerminator — Correct Only)
+**Output:** A configured WBPP run ready to debayer, measure, register, normalize, and integrate the lights.
 
-The first BlurX pass at `02:35` (`correct_only = true`) ran PSF correction without sharpening — tightening star profiles to remove trailing from the Seestar's limited aperture without introducing ringing artifacts. A second full BlurX pass at `02:38` (`correct_only = false`, `sharpen_nonstellar = 0.50`, `sharpen_stars = 0.50`) applied the full sharpening pass to both stars and extended structure.
+### 2. Debayer the CFA Frames
 
-Both passes used the **BlurXTerminator 4** ML model with `auto_nonstellar_psf = true`, letting the model estimate the PSF from the image rather than requiring a manual PSF measurement.
+**Use:** WBPP's debayer step, using PixInsight's Debayer process internally.
 
-### 5. Noise Reduction — Linear (NoiseXTerminator)
+**Set:**
 
-`NoiseXTerminator 3` ran at `02:42` on the linear (pre-stretch) stack:
+- Bayer pattern: `Auto`
+- Debayer method: `VNG`
 
+**Inspect:**
+
+- All 1146 frames should convert from CFA to RGB.
+- If the preview has incorrect color, the auto-detected Bayer pattern is the first thing to question.
+
+**Output:** RGB light frames ready for measurement and registration.
+
+### 3. Measure and Weight the Frames
+
+**Use:** WBPP frame measurement and weighting.
+
+**Set:**
+
+- Let WBPP measure FWHM, eccentricity, and SNR.
+- Keep SNR-weighted integration enabled.
+
+**Inspect:**
+
+- Look for obvious outliers: high eccentricity, unusually poor FWHM, or low SNR.
+- Do not reject frames just because they are below average; weighting lets weak frames contribute less.
+
+**Output:** A scored frame set that WBPP can use for reference selection and integration weights.
+
+### 4. Register the Frames
+
+**Use:** WBPP registration, using PixInsight's StarAlignment process internally.
+
+**Set:**
+
+- Let WBPP choose the reference frame automatically.
+- The selected reference for this run was `Light_IC 434_10.0s_LP_20260131-192733_d.xisf`.
+
+**Inspect:**
+
+- Registration accepted 1138 of 1146 frames.
+- The 8 failures were only 0.70% of the dataset, which is low enough to continue.
+- If failures cluster in time, inspect those subs for clouds, field jumps, or tracking glitches.
+
+**Output:** 1138 registered RGB frames.
+
+### 5. Apply Local Normalization
+
+**Use:** WBPP local normalization, using PixInsight's LocalNormalization process internally.
+
+**Set:**
+
+```text
+scale: 270
+rejection: enabled
+highClippingLevel: 0.85
+referenceRejectionThreshold: 3.00
 ```
+
+**Inspect:**
+
+- This step is important because the dataset spans two nights and has no flats.
+- Check that the background correction does not flatten real IC 434 nebulosity.
+- Alnitak creates a strong local illumination gradient, so local normalization should improve frame-to-frame consistency before stacking.
+
+**Output:** Registered frames with more consistent background illumination.
+
+### 6. Integrate the Stack
+
+**Use:** WBPP integration, using PixInsight's ImageIntegration and DrizzleIntegration processes.
+
+**Set:**
+
+- Rejection method: `Linear Fit Clipping`
+- Normalization: local rejection normalization
+- Combination: SNR-weighted average
+- Keep the drizzle-integrated master if WBPP produces both standard and drizzle outputs.
+
+**Inspect:**
+
+- The accepted integration should represent 1138 frames, or roughly 3h 10m of exposure.
+- Check the rejection maps for strong residual trails, hot pixels, or edge artifacts.
+- Compare the standard and drizzle masters before choosing the working master.
+
+**Output:** Final linear RGB master for manual processing.
+
+---
+
+## Part 2: Linear Processing Recipe
+
+Work on the linear master before stretching. Linear corrections are usually cleaner because the noise and gradients have not been amplified yet.
+
+### 1. Correct Orientation and Crop Edges
+
+**Use:** `FastRotation`, `ChannelCombination` if needed, then `DynamicCrop`.
+
+**Set:**
+
+- Rotate to the preferred composition after WBPP output.
+- Crop away the registration and rotation edges.
+- Keep the Horsehead, Flame, and Alnitak halo inside the frame.
+
+**Inspect:**
+
+- Do not crop so tightly that the Flame or Alnitak's halo feels clipped.
+- Check all corners for black wedges or stacking artifacts.
+
+**Output:** Clean linear RGB frame with usable edges.
+
+### 2. Remove Gradients with DynamicBackgroundExtraction
+
+**Use:** `Process > BackgroundModelization > DynamicBackgroundExtraction`
+
+**Set:**
+
+- Place samples manually in true background regions.
+- Avoid the Horsehead, IC 434 emission, the Flame, and Alnitak's halo.
+- Use a modest polynomial correction; this run used a second-order model.
+
+**Inspect:**
+
+- The background should become more even without erasing the red IC 434 sheet.
+- If the nebula loses contrast, remove or move samples that landed on faint emission.
+- If Alnitak's side of the frame over-corrects, reduce sample pressure near the halo.
+
+**Output:** Linear image with the light pollution gradient reduced.
+
+### 3. Correct Blur Before Sharpening
+
+**Use:** RC-Astro `BlurXTerminator`
+
+**Set:**
+
+- First pass: correction only.
+- Second pass: full correction with moderate sharpening.
+- This run used automatic nonstellar PSF estimation and a balanced star/nonstellar sharpening around `0.50`.
+
+**Inspect:**
+
+- Stars should become tighter without hard rings.
+- The Horsehead edge should gain definition without looking cut out.
+- If small stars become crunchy, reduce star sharpening before touching the nebula settings.
+
+**Output:** Linear image with corrected star profiles and cleaner structure.
+
+### 4. Reduce Linear Noise
+
+**Use:** RC-Astro `NoiseXTerminator`
+
+**Set:**
+
+```text
 denoise: 0.90
 denoise_color: 0.90
 detail: 0.15
 iterations: 2
-color_separation: true
+color_separation: enabled
 ```
 
-Aggressive denoising (0.9) on the linear stack is safe — the noise model is simpler pre-stretch, and preserving fine nebula detail at `detail = 0.15` prevents the model from over-smoothing the Horsehead's dark edge.
+**Inspect:**
 
-### 6. Star Removal (StarXTerminator)
+- The background should smooth out, but the Horsehead edge should remain intact.
+- If the nebula starts looking plastic, lower denoise or raise detail preservation.
 
-`StarXTerminator` ran at `02:45`. The `stars = true` mode saves a separate star layer for later recombination. Removing stars before stretch prevents Alnitak's saturated core from anchoring the histogram and pulling the rest of the image dark.
+**Output:** Linear image with lower background and chroma noise.
 
-### 7. Green Neutralization (SCNR)
+### 5. Separate Stars Before Stretching
 
-`SCNR` ran twice — once at `02:46` (pre-stretch) and again at `03:07` (post-DBE on a second pass). Both used:
+**Use:** RC-Astro `StarXTerminator`
 
-```
+**Set:**
+
+- Enable star output so the star layer is saved separately.
+- Apply to the linear image after blur and noise correction.
+
+**Inspect:**
+
+- The starless image should retain the nebula without large star holes.
+- The star layer should preserve Alnitak and the smaller field stars for later recombination.
+
+**Output:** A starless nebula image and a separate star layer.
+
+### 6. Neutralize Green Cast
+
+**Use:** `Process > NoiseReduction > SCNR`
+
+**Set:**
+
+```text
 colorToRemove: Green
 amount: 1.00
-protectionMethod: AverageNeutral
-preserveLightness: true
+protectionMethod: Average Neutral
+preserveLightness: enabled
 ```
 
-OSC sensors over-represent green (the Bayer matrix has 2 green pixels per 4), which shows up as a green cast in the sky background after debayering. Full-strength SCNR with average neutral protection removes the cast while preserving luminance.
+**Inspect:**
 
-### 8. Curves Adjustment (Pre-stretch)
+- The background should lose the OSC green cast.
+- Red Ha emission should not shift toward magenta.
 
-Two `CurvesTransformation` passes ran at `02:47` — brief micro-adjustments to the linear data before stretch, likely correcting a residual color cast or nudging the channel balance toward the Ha-dominant red.
+**Output:** Linear starless image with cleaner color balance.
 
-### 9. Background Blackpoint (PixelMath)
+---
 
-At `03:42`, three rapid `PixelMath` passes applied a luminance-weighted blackpoint clipping formula:
+## Part 3: Stretch and Nonlinear Processing Recipe
 
-```
+After stretch, the image is easier to judge visually, but noise and halos are also easier to exaggerate. Make smaller adjustments and inspect often.
+
+### 1. Set a Robust Blackpoint with PixelMath
+
+**Use:** `Process > PixelMath > PixelMath`
+
+**Set:**
+
+Use the luminance-weighted median and MAD pattern from this run:
+
+```text
 cr=0.2126; cg=0.7152; cb=0.0722;
 Med = cr*med($T[0]) + cg*med($T[1]) + cb*med($T[2]);
 Sig = 1.4826*(cr*MAD($T[0]) + cg*MAD($T[1]) + cb*MAD($T[2]));
@@ -205,61 +327,139 @@ BP = iif(BPraw < MinC, MinC, BPraw);
 Rescaled = ($T - BP) / (1 - BP);
 ```
 
-This Rec.601-weighted median-and-MAD formula clips the background at 5 sigma below the luminance median and rescales to [0,1]. More robust than a fixed black clip — it adapts to the actual background level after DBE.
+**Inspect:**
 
-### 10. Stretch (Statistical Stretch Script)
+- The background should be controlled but not clipped.
+- The faint IC 434 emission covers a large part of the field, so avoid forcing the whole background to black.
 
-At `03:42`, the `statisticalstretch.js` script stretched the image:
+**Output:** Linear image with a statistically controlled blackpoint.
 
-```
+### 2. Stretch the Starless Image
+
+**Use:** `statisticalstretch.js`
+
+**Set:**
+
+```text
 targetMedian: 0.27
 curvesBoost: 0.37
-linkedStretch: true
+linkedStretch: enabled
 blackpointSigma: 3
 numIterations: 1
 ```
 
-A target median of 0.27 is slightly above the typical 0.2–0.25 range — pushing the midtone brighter to lift the faint IC 434 emission above the noise floor. The `curvesBoost = 0.37` adds an S-curve bump during the stretch for extra contrast. Linked stretch preserves color ratios, avoiding channel drift on the Ha emission.
+**Inspect:**
 
-### 11. Post-Stretch Noise Reduction (NoiseXTerminator)
+- IC 434 should lift out of the background without washing out.
+- Linked stretch should preserve the red-dominant color balance.
+- If the background becomes too bright, reduce the target median before adding more contrast.
 
-At `03:42`, a second NoiseXT pass ran on the stretched image with the same parameters (`denoise = 0.90`, `detail = 0.15`). Post-stretch noise reduction catches amplified shadow noise that becomes visible after the histogram stretch.
+**Output:** Nonlinear starless image.
 
-### 12. Channel Work and Recombination
+### 3. Clean Up Stretch-Amplified Noise
 
-At `03:45`, `ChannelExtraction` separated the RGB channels — likely to work the red/Ha channel independently. This was followed by a `CurvesTransformation` at `03:42` (logged just before) to enhance the red channel's Ha signal.
+**Use:** RC-Astro `NoiseXTerminator`
 
-### 13. Local Contrast — LocalHistogramEqualization
+**Set:**
 
-At `04:15`, `LocalHistogramEqualization` (LHE) ran with:
+- Start from the same conservative detail-preserving settings used in the linear pass.
+- Apply less aggressively if the stretched image already looks smooth.
 
-```
+**Inspect:**
+
+- Look at the faint red emission around the Horsehead, not just the dark sky.
+- Avoid wiping out soft Ha texture.
+
+**Output:** Nonlinear starless image with controlled shadow noise.
+
+### 4. Work the Red Channel if Needed
+
+**Use:** `ChannelExtraction`, then `CurvesTransformation`
+
+**Set:**
+
+- Extract RGB channels.
+- Use the red channel as the main reference for Ha contrast.
+- Apply small curve adjustments rather than a single large move.
+
+**Inspect:**
+
+- The Horsehead silhouette should separate more clearly from IC 434.
+- The Flame should not become oversaturated or disconnected from the surrounding field.
+
+**Output:** Color-balanced nonlinear image with stronger Ha contrast.
+
+### 5. Add Local Contrast
+
+**Use:** `Process > IntensityTransformations > LocalHistogramEqualization`
+
+**Set:**
+
+```text
 radius: 124
 slopeLimit: 2.0
 amount: 0.630
 histogramBins: 8-bit
-circularKernel: true
+circularKernel: enabled
 ```
 
-LHE at a 124-pixel radius enhances local contrast across mid-scale structures — useful for bringing out the Horsehead's dark pillar edge against the IC 434 background without over-boosting noise in the flat sky regions. The 2.0 slope limit caps amplification to prevent halos.
+**Inspect:**
 
-### 14. HDR Compression (HDRMultiscaleTransform)
+- The Horsehead edge and Flame structure should gain local definition.
+- Watch for halos around Alnitak and bright stars.
+- If flat background areas become noisy, reduce amount before changing radius.
 
-At `04:17`, `HDRMultiscaleTransform` ran with:
+**Output:** Nonlinear image with stronger mid-scale nebula contrast.
 
-```
+### 6. Compress Bright Structure
+
+**Use:** `Process > MultiscaleProcessing > HDRMultiscaleTransform`
+
+**Set:**
+
+```text
 numberOfLayers: 5
-invertedIterations: true
+invertedIterations: enabled
 scalingFunction: B3 Spline (5)
 largeScaleDeringing: 0.250
-toIntensity: true
+toIntensity: enabled
 ```
 
-HDRMT with inverted iterations compresses large-scale highlights — particularly Alnitak's blown-out core — while preserving the fine nebula detail captured in the lower wavelet layers. The B3 Spline 5-layer decomposition reaches down to ~32-pixel structures.
+**Inspect:**
 
-### 15. Curves and Final Noise Passes
+- Alnitak's halo should feel less dominant.
+- The Flame should keep internal structure without looking flattened.
+- HDRMT cannot recover saturated detail; it only compresses the surrounding bright structure.
 
-Three final `CurvesTransformation` passes ran between `04:22–04:30` — fine-tuning the tone curve to taste. Two more `NoiseXTerminator` passes at `04:24` and `04:39` (each ~2–3 seconds) cleaned up noise introduced by the LHE and HDRMT contrast passes.
+**Output:** Nonlinear image with better highlight control.
+
+### 7. Finish with Curves and Star Recombination
+
+**Use:** `CurvesTransformation`, then recombine with the saved star layer.
+
+**Set:**
+
+- Use small S-curve moves for contrast.
+- Use saturation carefully on the red channel.
+- Add stars back after the nebula stretch is stable.
+
+**Inspect:**
+
+- Alnitak should not dominate the histogram again after recombination.
+- Small stars should look present but not sharpened beyond the nebula.
+- The Horsehead silhouette should remain dark without clipping into a featureless black patch.
+
+**Output:** Final RGB image.
+
+---
+
+## What To Watch For
+
+- **DBE samples on nebulosity:** IC 434 is broad and faint. Bad samples can subtract the target itself.
+- **Alnitak biasing the stretch:** separating stars before stretch keeps the nebula from being held down by the bright star.
+- **Over-denoising:** NoiseXTerminator can make faint Ha texture look synthetic if the denoise amount is too high for the stretched image.
+- **Local contrast halos:** LHE and HDRMT both help the Flame and Horsehead, but both can create halos near bright stars.
+- **False black background:** this field is not empty sky. A very dark background usually means faint emission has been clipped.
 
 ---
 
@@ -268,20 +468,8 @@ Three final `CurvesTransformation` passes ran between `04:22–04:30` — fine-t
 | Stage | Input | Output |
 |-------|-------|--------|
 | Debayering | 1146 CFA frames | 1146 RGB frames |
-| Registration | 1146 attempted | 1138 accepted · 8 rejected |
-| Stack integration | 1138 × 10 s | ~3h 10m |
-| Post-processing | Linear master | Fully processed RGB |
+| Registration | 1146 attempted | 1138 accepted, 8 rejected |
+| Stack integration | 1138 x 10 s | ~3h 10m |
+| Post-processing | Linear RGB master | Finished RGB image |
 
-**Yield: 99.3%** — exceptional. The Horsehead's dark silhouette and the Flame's thermal structure both resolved cleanly from a Bortle 8 site.
-
----
-
-## Notes and Observations
-
-The two-night structure worked well. Enabling local normalization was the right call — the stack was notably smoother than single-night OSC datasets. The reference frame auto-selected from the second night confirms Jan 31 had better seeing.
-
-The statistical stretch at `targetMedian = 0.27` was deliberately aggressive: lifting the faint IC 434 emission meant accepting a slightly brighter background, but the LP gradient was well-corrected by DBE and SCNR beforehand. Alnitak's core is fully saturated in the final image; HDRMultiscaleTransform compressed the halo substantially but couldn't recover detail that wasn't captured in 10-second subs.
-
-StarXTerminator removing stars before stretch was important for this field. Without it, Alnitak would have dominated the histogram and crushed the nebula midtones.
-
-The PixelMath blackpoint formula was a particularly useful pattern — the Rec.601-weighted median approach adapts cleanly to backgrounds that aren't uniformly dark after DBE, which is the case here with IC 434's diffuse Ha emission occupying a large fraction of the frame.
+**Yield: 99.3%.** The key choices were local normalization for the two-night, no-flat dataset; DBE for the urban gradient; star separation before stretching; and controlled local contrast to keep the Horsehead and Flame structured without letting Alnitak take over the frame.

--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -1657,3 +1657,517 @@ body.astro-page .article-shell {
     font-size: 30px;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════
+   ASTROPHOTOGRAPHY LISTING PAGE
+   Aurora palette: gold × cyan over deep navy.
+   Sidebar 95%, header 95%. Headers: mono + sans-serif combo.
+   ═══════════════════════════════════════════════════════════ */
+
+/* ── Aurora palette tokens (scoped to listing wrapper) ── */
+.astro-listing-wrap {
+  /* Aurora palette */
+  --al-bg:        #0a0e16;
+  --al-bg-soft:   #11151f;
+  --al-panel:     rgba(17, 21, 31, 0.84);
+  --al-rule:      rgba(255, 154, 60, 0.18);
+  --al-rule-soft: rgba(255, 154, 60, 0.10);
+  --al-ink:       #ece5d3;
+  --al-ink-mid:   #c8bda3;
+  --al-ink-sub:   #9a8e75;
+  --al-mute:      rgba(154, 142, 117, 0.65);
+  --al-orange:    #ff9a3c;
+  --al-orange-d:  #d36e10;
+  --al-amber:     #ffc572;
+  --al-blue:      #6ad5e8;
+  --al-blue-d:    #38a4b9;
+  --al-cream:     #fff2d8;
+  /* Scale knobs */
+  --al-side-scale: 0.95;
+  --al-hero-scale: 0.95;
+  /* Fonts */
+  --al-mono:   'JetBrains Mono', ui-monospace, monospace;
+  --al-serif:  'Source Serif 4', 'Source Serif Pro', Georgia, serif;
+  /* Display = mono headline (eyebrow) + bold sans for large headers */
+  --al-display-h: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Helvetica Neue', Arial, sans-serif;
+
+  position: relative;
+  background: var(--al-bg);
+  color: var(--al-ink);
+  min-height: calc(100vh - var(--nav-h));
+}
+
+/* ── Scene background ── */
+.astro-listing-wrap .al-scene-bg {
+  position: fixed; inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(rgba(106, 213, 232, 0.05) 0.5px, transparent 0.5px),
+    radial-gradient(900px 600px at 12% -10%, rgba(255, 154, 60, 0.08), transparent 70%),
+    radial-gradient(900px 700px at 88% 110%, rgba(106, 213, 232, 0.07), transparent 70%),
+    repeating-linear-gradient(0deg, rgba(106,213,232,0.015) 0 1px, transparent 1px 4px);
+  background-size: 220px 220px, 100% 100%, 100% 100%, 100% 100%;
+}
+
+/* ── Minimal mission bar ── */
+.astro-listing-wrap .al-mission-bar {
+  position: sticky;
+  top: var(--nav-h);
+  z-index: 10;
+  background: rgba(10, 14, 22, 0.94);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--al-rule);
+}
+.astro-listing-wrap .al-status-strip {
+  padding: 10px 40px;
+  display: flex; align-items: center; gap: 22px;
+  font-family: var(--al-mono);
+  font-size: 11px;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  color: var(--al-mute);
+}
+.astro-listing-wrap .al-back-link {
+  color: var(--al-mute);
+  text-decoration: none;
+  transition: color .15s;
+}
+.astro-listing-wrap .al-back-link:hover { color: var(--al-orange); }
+.astro-listing-wrap .al-spacer { flex: 1; }
+.astro-listing-wrap .al-status-live {
+  display: inline-flex; align-items: center; gap: 7px;
+  color: var(--al-blue);
+  white-space: nowrap;
+}
+.astro-listing-wrap .al-status-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--al-blue);
+  box-shadow: 0 0 10px var(--al-blue);
+  animation: al-pulse 2.4s ease-in-out infinite;
+  flex-shrink: 0;
+}
+@keyframes al-pulse { 50% { opacity: .55; } }
+
+/* ── Main listing container ── */
+.astro-listing-wrap .al-listing {
+  position: relative; z-index: 1;
+  padding: 0 40px 56px;
+}
+
+/* ── Header ── */
+.astro-listing-wrap .al-head {
+  padding: calc(28px * var(--al-hero-scale)) 0 22px;
+  border-bottom: 1px solid var(--al-rule);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  align-items: end;
+}
+.astro-listing-wrap .al-head .al-meta {
+  font-family: var(--al-mono);
+  font-size: 11px;
+  letter-spacing: 1.8px;
+  text-transform: uppercase;
+  color: var(--al-mute);
+  margin-bottom: 10px;
+}
+.astro-listing-wrap .al-head .al-meta .al-accent-blue { color: var(--al-blue); }
+/* Large heading: bold sans-serif with mono eyebrow via ::before */
+.astro-listing-wrap .al-head h1 {
+  font-family: var(--al-display-h);
+  font-weight: 700;
+  font-size: clamp(30px, calc(3.8vw * var(--al-hero-scale)), 50px);
+  line-height: 0.98;
+  letter-spacing: -1.5px;
+  color: var(--al-cream);
+  margin-bottom: 12px;
+  text-wrap: balance;
+}
+.astro-listing-wrap .al-head h1 .al-accent {
+  color: var(--al-orange);
+  font-family: var(--al-mono);
+  font-weight: 600;
+  font-size: 0.68em;
+  letter-spacing: 1px;
+  vertical-align: baseline;
+}
+.astro-listing-wrap .al-head .al-sub {
+  font-family: var(--al-serif);
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--al-ink-mid);
+  max-width: 540px;
+}
+.astro-listing-wrap .al-head .al-stats {
+  display: grid;
+  grid-template-columns: auto auto auto;
+  gap: 20px 30px;
+  align-self: end;
+  padding-bottom: 6px;
+}
+.astro-listing-wrap .al-stat .al-k {
+  font-family: var(--al-mono);
+  font-size: 10px;
+  letter-spacing: 1.8px;
+  text-transform: uppercase;
+  color: var(--al-mute);
+  margin-bottom: 2px;
+}
+.astro-listing-wrap .al-stat .al-v {
+  font-family: var(--al-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: calc(22px * var(--al-hero-scale));
+  color: var(--al-cream);
+}
+.astro-listing-wrap .al-stat .al-v.is-orange { color: var(--al-orange); }
+.astro-listing-wrap .al-stat .al-v.is-blue   { color: var(--al-blue); }
+.astro-listing-wrap .al-stat .al-v.is-amber  { color: var(--al-amber); }
+
+/* ── Section label ── */
+.astro-listing-wrap .al-sec-label {
+  display: flex; align-items: center; gap: 14px;
+  margin: 36px 0 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px dashed var(--al-orange);
+  --al-label-c: var(--al-orange);
+}
+.astro-listing-wrap .al-sec-label--blue { border-bottom-color: var(--al-blue); --al-label-c: var(--al-blue); }
+.astro-listing-wrap .al-sec-num {
+  color: var(--al-label-c);
+  font-family: var(--al-mono);
+  font-size: 11px;
+  letter-spacing: 2px;
+}
+.astro-listing-wrap .al-sec-title {
+  font-family: var(--al-display-h);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 2.5px;
+  color: var(--al-cream);
+  text-transform: uppercase;
+}
+.astro-listing-wrap .al-sec-rule { flex: 1; height: 1px; background: var(--al-rule); }
+.astro-listing-wrap .al-sec-frame {
+  font-family: var(--al-mono);
+  font-size: 10px;
+  color: var(--al-mute);
+  letter-spacing: 1.6px;
+}
+
+/* ── Featured session card ── */
+.astro-listing-wrap .al-featured {
+  display: grid;
+  grid-template-columns: 1.35fr 1fr;
+  overflow: hidden;
+  background: var(--al-panel);
+  border: 1px solid var(--al-rule);
+  position: relative;
+  cursor: pointer;
+  transition: border-color .18s;
+}
+.astro-listing-wrap .al-featured:hover { border-color: color-mix(in srgb, var(--al-orange) 50%, var(--al-rule)); }
+.astro-listing-wrap .al-featured::before,
+.astro-listing-wrap .al-featured::after {
+  content: '';
+  position: absolute;
+  width: 13px; height: 13px;
+  pointer-events: none; z-index: 3;
+}
+.astro-listing-wrap .al-featured::before {
+  top: -1px; left: -1px;
+  border-top: 2px solid var(--al-orange);
+  border-left: 2px solid var(--al-orange);
+}
+.astro-listing-wrap .al-featured::after {
+  bottom: -1px; right: -1px;
+  border-bottom: 2px solid var(--al-orange);
+  border-right: 2px solid var(--al-orange);
+}
+
+.astro-listing-wrap .al-featured-img {
+  position: relative;
+  background: #050408;
+  min-height: 440px;
+  overflow: hidden;
+}
+.astro-listing-wrap .al-featured-img > * {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  display: block;
+  object-fit: cover;
+}
+.astro-listing-wrap .al-featured-img::after {
+  content: '';
+  position: absolute; inset: 0;
+  background:
+    radial-gradient(120% 80% at 30% 30%, transparent 0%, rgba(10,14,22,0.45) 80%),
+    linear-gradient(90deg, transparent 70%, rgba(10,14,22,0.65) 100%);
+  pointer-events: none;
+  z-index: 1;
+}
+.astro-listing-wrap .al-hud-tag {
+  position: absolute; bottom: 18px; left: 18px;
+  z-index: 3;
+  display: flex; flex-direction: column; gap: 4px;
+  font-family: var(--al-mono);
+  font-size: 11px;
+  letter-spacing: 1.6px;
+  color: var(--al-blue);
+  text-transform: uppercase;
+}
+.astro-listing-wrap .al-hud-tag .al-desig-big {
+  font-family: var(--al-display-h);
+  font-weight: 700;
+  font-size: 28px;
+  letter-spacing: -0.5px;
+  color: var(--al-cream);
+  margin-bottom: 2px;
+  text-transform: none;
+}
+.astro-listing-wrap .al-hud-scale {
+  position: absolute; bottom: 18px; right: 18px;
+  z-index: 3;
+  display: flex; align-items: center; gap: 8px;
+  padding: 5px 10px;
+  background: rgba(10,14,22,0.75);
+  border: 1px solid var(--al-rule);
+  font-family: var(--al-mono);
+  font-size: 10px; letter-spacing: 1.6px;
+  color: var(--al-blue);
+}
+.astro-listing-wrap .al-hud-scale .al-bar {
+  width: 56px; height: 1px; background: var(--al-blue);
+}
+.al-corner { position: absolute; width: 20px; height: 20px; border-color: var(--al-orange); z-index: 4; }
+.al-corner.tl { top: 10px; left: 10px;  border-top: 1.5px solid; border-left: 1.5px solid; }
+.al-corner.tr { top: 10px; right: 10px; border-top: 1.5px solid; border-right: 1.5px solid; }
+.al-corner.bl { bottom: 10px; left: 10px;  border-bottom: 1.5px solid; border-left: 1.5px solid; }
+.al-corner.br { bottom: 10px; right: 10px; border-bottom: 1.5px solid; border-right: 1.5px solid; }
+
+.astro-listing-wrap .al-featured-body {
+  padding: 26px 28px 22px;
+  display: flex; flex-direction: column; gap: 14px;
+  background: rgba(10, 14, 22, 0.5);
+  border-left: 1px solid var(--al-rule);
+}
+.astro-listing-wrap .al-kicker {
+  font-family: var(--al-mono);
+  font-size: 11px; letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--al-orange);
+}
+.astro-listing-wrap .al-featured-body h2 {
+  font-family: var(--al-display-h);
+  font-weight: 700;
+  font-size: calc(28px * var(--al-hero-scale));
+  line-height: 1.08;
+  letter-spacing: -0.8px;
+  color: var(--al-cream);
+  text-wrap: balance;
+}
+.astro-listing-wrap .al-featured-desc {
+  font-family: var(--al-serif);
+  font-size: 15px; line-height: 1.55;
+  color: var(--al-ink-mid);
+}
+.astro-listing-wrap .al-telem-row {
+  display: grid; grid-template-columns: repeat(2, 1fr);
+  gap: 10px 18px; padding: 12px 0;
+  border-top: 1px solid var(--al-rule);
+  border-bottom: 1px solid var(--al-rule);
+}
+.astro-listing-wrap .al-telem-row .al-it .al-k {
+  font-family: var(--al-mono);
+  font-size: 10px; letter-spacing: 1.8px;
+  text-transform: uppercase; color: var(--al-mute);
+}
+.astro-listing-wrap .al-telem-row .al-it .al-v {
+  font-family: var(--al-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 14px; color: var(--al-ink); margin-top: 2px;
+}
+.astro-listing-wrap .al-telem-row .al-it .al-v.amber { color: var(--al-amber); }
+.astro-listing-wrap .al-telem-row .al-it .al-v.blue  { color: var(--al-blue); }
+
+.astro-listing-wrap .al-featured-actions {
+  display: flex; justify-content: flex-end; align-items: center;
+  margin-top: 4px;
+}
+.astro-listing-wrap .al-btn-open {
+  font-family: var(--al-mono);
+  font-size: 12px; letter-spacing: 1.8px; text-transform: uppercase;
+  background: var(--al-orange); color: var(--al-bg);
+  padding: 10px 18px; border: none; cursor: pointer; font-weight: 600;
+  text-decoration: none; display: inline-block;
+  transition: background .15s;
+}
+.astro-listing-wrap .al-btn-open:hover { background: var(--al-amber); }
+
+/* ── Session grid ── */
+.astro-listing-wrap .al-session-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 14px;
+}
+.astro-listing-wrap .al-card {
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  background: var(--al-panel);
+  border: 1px solid var(--al-rule);
+  position: relative;
+  transition: transform .18s, border-color .18s;
+  --al-bracket: var(--al-blue);
+}
+.astro-listing-wrap .al-card::before,
+.astro-listing-wrap .al-card::after {
+  content: '';
+  position: absolute; width: 9px; height: 9px; pointer-events: none;
+}
+.astro-listing-wrap .al-card::before {
+  top: -1px; left: -1px;
+  border-top: 1.5px solid var(--al-bracket);
+  border-left: 1.5px solid var(--al-bracket);
+}
+.astro-listing-wrap .al-card::after {
+  bottom: -1px; right: -1px;
+  border-bottom: 1.5px solid var(--al-bracket);
+  border-right: 1.5px solid var(--al-bracket);
+}
+.astro-listing-wrap .al-card:not(.is-locked) { cursor: pointer; }
+.astro-listing-wrap .al-card:not(.is-locked):hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, var(--al-orange) 60%, var(--al-rule));
+  --al-bracket: var(--al-orange);
+}
+.astro-listing-wrap .al-card.is-locked { opacity: 0.60; }
+
+.astro-listing-wrap .al-card-thumb {
+  position: relative; height: 200px;
+  background: #050408; overflow: hidden;
+}
+.astro-listing-wrap .al-card-thumb img,
+.astro-listing-wrap .al-card-thumb svg {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%; object-fit: cover; display: block;
+}
+.astro-listing-wrap .al-card-thumb::after {
+  content: '';
+  position: absolute; inset: 0;
+  background: linear-gradient(180deg, transparent 50%, rgba(10,14,22,0.8) 100%);
+  pointer-events: none;
+}
+.astro-listing-wrap .al-card .al-card-desig {
+  position: absolute; bottom: 12px; left: 14px; z-index: 2;
+  font-family: var(--al-display-h);
+  font-weight: 700; font-size: 20px;
+  color: var(--al-cream); letter-spacing: -0.4px;
+}
+.astro-listing-wrap .al-card .al-session-tag {
+  position: absolute; top: 10px; left: 12px; z-index: 2;
+  padding: 3px 8px;
+  background: rgba(10,14,22,0.75);
+  border: 1px solid var(--al-rule);
+  font-family: var(--al-mono); font-size: 10px;
+  letter-spacing: 1.6px; text-transform: uppercase;
+  color: var(--al-blue);
+}
+.astro-listing-wrap .al-card.is-locked .al-session-tag { color: var(--al-mute); }
+
+.astro-listing-wrap .al-card-body {
+  padding: 14px 16px 16px;
+  display: flex; flex-direction: column; gap: 10px; flex: 1;
+}
+.astro-listing-wrap .al-card-title {
+  font-family: var(--al-display-h);
+  font-weight: 600; font-size: 16px; line-height: 1.3;
+  color: var(--al-ink); letter-spacing: -0.2px;
+}
+.astro-listing-wrap .al-card-desc {
+  font-family: var(--al-serif);
+  font-size: 13px; line-height: 1.5; color: var(--al-ink-sub);
+}
+.astro-listing-wrap .al-card-telem {
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 8px; padding-top: 10px;
+  border-top: 1px dashed var(--al-rule);
+  margin-top: auto;
+}
+.astro-listing-wrap .al-card-telem .al-it .al-k {
+  font-family: var(--al-mono); font-size: 9.5px;
+  letter-spacing: 1.6px; text-transform: uppercase; color: var(--al-mute);
+}
+.astro-listing-wrap .al-card-telem .al-it .al-v {
+  font-family: var(--al-mono); font-variant-numeric: tabular-nums;
+  font-size: 13px; color: var(--al-ink); margin-top: 1px;
+}
+.astro-listing-wrap .al-card-telem .al-it .al-v.amber { color: var(--al-amber); }
+.astro-listing-wrap .al-card-telem .al-it .al-v.blue  { color: var(--al-blue); }
+.astro-listing-wrap .al-card-tags {
+  display: flex; flex-wrap: wrap; gap: 5px;
+  font-family: var(--al-mono); font-size: 10px;
+  letter-spacing: 1.4px; text-transform: uppercase;
+}
+.astro-listing-wrap .al-tag { padding: 2px 7px; border: 1px solid currentColor; color: var(--al-ink-sub); }
+.astro-listing-wrap .al-tag.is-orange { color: var(--al-orange); }
+.astro-listing-wrap .al-tag.is-blue   { color: var(--al-blue); }
+.astro-listing-wrap .al-tag.is-amber  { color: var(--al-amber); }
+
+/* ── Methodology section ── */
+.astro-listing-wrap .al-method {
+  margin-top: 40px; padding: 22px 24px;
+  background: var(--al-panel); border: 1px solid var(--al-rule);
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 22px;
+  position: relative;
+}
+.astro-listing-wrap .al-method::before,
+.astro-listing-wrap .al-method::after {
+  content: '';
+  position: absolute; width: 11px; height: 11px; pointer-events: none;
+}
+.astro-listing-wrap .al-method::before {
+  top: -1px; left: -1px;
+  border-top: 2px solid var(--al-amber);
+  border-left: 2px solid var(--al-amber);
+}
+.astro-listing-wrap .al-method::after {
+  bottom: -1px; right: -1px;
+  border-bottom: 2px solid var(--al-amber);
+  border-right: 2px solid var(--al-amber);
+}
+.astro-listing-wrap .al-method-col .al-mk {
+  font-family: var(--al-mono); font-size: 10px;
+  letter-spacing: 1.8px; text-transform: uppercase;
+  color: var(--al-amber); margin-bottom: 8px;
+}
+.astro-listing-wrap .al-method-col .al-mv {
+  font-family: var(--al-serif);
+  font-size: 14px; line-height: 1.5; color: var(--al-ink-mid);
+}
+
+/* ── Footer ── */
+.astro-listing-wrap .al-footer {
+  border-top: 1px solid var(--al-rule);
+  margin-top: 28px; padding-top: 16px;
+  display: flex; justify-content: space-between;
+  font-family: var(--al-mono); font-size: 10.5px;
+  letter-spacing: 2px; text-transform: uppercase; color: var(--al-mute);
+}
+.astro-listing-wrap .al-footer .al-ok { color: var(--al-orange); }
+
+/* ── Responsive ── */
+@media (max-width: 1100px) {
+  .astro-listing-wrap .al-listing { padding: 0 28px 48px; }
+  .astro-listing-wrap .al-status-strip { padding-left: 28px; padding-right: 28px; }
+}
+@media (max-width: 860px) {
+  .astro-listing-wrap .al-listing { padding: 0 20px 40px; }
+  .astro-listing-wrap .al-status-strip { padding-left: 20px; padding-right: 20px; }
+  .astro-listing-wrap .al-head { grid-template-columns: 1fr; }
+  .astro-listing-wrap .al-head .al-stats { grid-template-columns: repeat(3, auto); justify-content: start; gap: 14px 24px; }
+  .astro-listing-wrap .al-featured { grid-template-columns: 1fr; }
+  .astro-listing-wrap .al-featured-img { min-height: 280px; }
+  .astro-listing-wrap .al-featured-body { border-left: none; border-top: 1px solid var(--al-rule); }
+  .astro-listing-wrap .al-method { grid-template-columns: repeat(2, 1fr); }
+}

--- a/astrophotography.html
+++ b/astrophotography.html
@@ -1,60 +1,311 @@
 ---
 layout: default
 title: Astrophotography
-description: Astrophotography work by Chaitanya Khoje.
+description: Astrophotography sessions, imaging workflows, and processing notes by Chaitanya Khoje.
 permalink: /astrophotography/
 theme: dark
 hide_theme_toggle: true
 body_class: astro-page
 ---
 
-<div class="astro-scene" aria-hidden="true">
-  <div class="astro-scene-image" style="background-image: url('{{ '/assets/images/soulnebula.jpg' | relative_url }}');"></div>
-</div>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&display=swap" rel="stylesheet" />
 
-<div class="article-shell">
-  <article class="post-wrap astro-wrap" id="main-content" tabindex="-1">
-    <a class="back-link" href="{{ '/' | relative_url }}">← Portfolio</a>
+{% assign astro_posts = site.posts | where: "layout", "astro-workflow" | sort: "date" | reverse %}
+{% assign total_sessions = astro_posts.size %}
+{% assign total_frames = 0 %}
+{% for post in astro_posts %}
+  {% if post.capture and post.capture.frames %}
+    {% assign total_frames = total_frames | plus: post.capture.frames %}
+  {% endif %}
+{% endfor %}
 
-    <header class="post-header">
-      <div class="post-header-meta">
-        <span>Astrophotography</span>
+<div class="astro-listing-wrap">
+  <div class="al-scene-bg" aria-hidden="true"></div>
+
+  <!-- Minimal mission bar -->
+  <div class="al-mission-bar">
+    <div class="al-status-strip">
+      <a class="al-back-link" href="{{ '/' | relative_url }}">← Portfolio</a>
+      <span class="al-spacer"></span>
+      <span class="al-status-live">
+        <span class="al-status-dot"></span>
+        Station · Operational
+      </span>
+    </div>
+  </div>
+
+  <div class="al-listing">
+
+    <!-- Header -->
+    <header class="al-head">
+      <div>
+        <div class="al-meta">
+          Field Log · Imaging Sessions · <span class="al-accent-blue">Index 001 / {{ total_sessions }}</span>
+        </div>
+        <h1>Astrophotography.<br>
+          <span class="al-accent">Sessions &amp; workflows.</span>
+        </h1>
+        <p class="al-sub">
+          A field log of imaging sessions — acquisition notes, calibration, and the processing pipeline behind each frame. Each entry runs through the full pipeline from raw subs to final stretch.
+        </p>
       </div>
-      <h1 class="post-h1">Astrophotography</h1>
-      <p class="post-subtitle">A quiet space for night-sky images, observing notes, and the technical side of capturing faint light.</p>
+      <div class="al-stats">
+        <div class="al-stat">
+          <div class="al-k">Sessions</div>
+          <div class="al-v is-orange">{{ total_sessions }}</div>
+        </div>
+        <div class="al-stat">
+          <div class="al-k">Frames</div>
+          <div class="al-v">{{ total_frames | default: "—" }}</div>
+        </div>
+        <div class="al-stat">
+          <div class="al-k">Bortle</div>
+          <div class="al-v is-amber">7–8</div>
+        </div>
+      </div>
     </header>
 
-    <div class="prose">
-      <p>Workflow logs and processed images from nights behind the telescope. Each entry covers the full pipeline — acquisition, stacking, and post-processing.</p>
+    {% if astro_posts.size > 0 %}
+    {% assign featured_post = astro_posts.first %}
+    {% comment %}rest_posts built in the loop below via offset:1{% endcomment %}
 
-      {% assign astro_posts = site.posts | where: "layout", "astro-workflow" %}
-      {% if astro_posts.size > 0 %}
-      <h2>Sessions</h2>
-      {% for post in astro_posts %}
-      <div class="post-row">
-        <div class="post-row-body">
-          <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
-          {% if post.description %}<p class="post-desc">{{ post.description }}</p>{% endif %}
+    <!-- Featured session -->
+    <div class="al-sec-label">
+      <span class="al-sec-num">§ 01</span>
+      <h2 class="al-sec-title">Featured Session</h2>
+      <div class="al-sec-rule"></div>
+      <span class="al-sec-frame">Most recent · {{ featured_post.date | date: "%b %Y" }}</span>
+    </div>
+
+    <a class="al-featured" href="{{ featured_post.url | relative_url }}">
+      <div class="al-featured-img">
+        {% if featured_post.hero_image %}
+        <img src="{{ featured_post.hero_image | relative_url }}" alt="{{ featured_post.title }}" />
+        {% else %}
+        <svg viewBox="0 0 720 440" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <radialGradient id="al-sky" cx="50%" cy="50%" r="80%">
+              <stop offset="0%" stop-color="#0c1020"/>
+              <stop offset="100%" stop-color="#020308"/>
+            </radialGradient>
+            <radialGradient id="al-ha" cx="50%" cy="55%" r="65%">
+              <stop offset="0%" stop-color="#d4622e" stop-opacity="0"/>
+              <stop offset="35%" stop-color="#d4622e" stop-opacity="0.55"/>
+              <stop offset="70%" stop-color="#a73a4a" stop-opacity="0.45"/>
+              <stop offset="100%" stop-color="#3a1a28" stop-opacity="0"/>
+            </radialGradient>
+            <radialGradient id="al-core" cx="50%" cy="48%" r="24%">
+              <stop offset="0%" stop-color="#fff2e0"/>
+              <stop offset="22%" stop-color="#ffc878" stop-opacity="0.95"/>
+              <stop offset="55%" stop-color="#ff9a3c" stop-opacity="0.7"/>
+              <stop offset="100%" stop-color="#7a2030" stop-opacity="0"/>
+            </radialGradient>
+            <radialGradient id="al-oiii" cx="68%" cy="30%" r="26%">
+              <stop offset="0%" stop-color="#6ad5e8" stop-opacity="0.8"/>
+              <stop offset="55%" stop-color="#38a4b9" stop-opacity="0.4"/>
+              <stop offset="100%" stop-color="#1a2a40" stop-opacity="0"/>
+            </radialGradient>
+            <filter id="al-glow"><feGaussianBlur stdDeviation="0.7"/></filter>
+          </defs>
+          <rect width="720" height="440" fill="url(#al-sky)"/>
+          <ellipse cx="360" cy="240" rx="380" ry="185" fill="url(#al-ha)" opacity="0.92"/>
+          <ellipse cx="490" cy="135" rx="124" ry="80" fill="url(#al-oiii)"/>
+          <ellipse cx="360" cy="216" rx="136" ry="76" fill="url(#al-core)"/>
+          <path d="M 310 290 C 307 260, 312 236, 336 232 C 344 208, 356 200, 368 204 C 376 192, 392 192, 396 208 C 408 208, 416 220, 412 236 C 424 244, 428 264, 416 276 C 420 296, 404 312, 384 312 L 384 356 L 316 356 Z" fill="#08090f" opacity="0.9"/>
+          <circle cx="120" cy="72" r="3.4" fill="#fff6e8" opacity="0.28" filter="url(#al-glow)"/><circle cx="120" cy="72" r="1.5" fill="#fffaf0"/>
+          <circle cx="240" cy="140" r="4" fill="#fff6e8" opacity="0.22" filter="url(#al-glow)"/><circle cx="240" cy="140" r="1.8" fill="#fffaf0"/>
+          <circle cx="360" cy="100" r="2.8" fill="#fff6e8" opacity="0.3" filter="url(#al-glow)"/><circle cx="360" cy="100" r="1.2" fill="#fffaf0"/>
+          <circle cx="480" cy="180" r="3.6" fill="#fff6e8" opacity="0.22" filter="url(#al-glow)"/><circle cx="480" cy="180" r="1.6" fill="#fffaf0"/>
+          <circle cx="600" cy="60" r="2.4" fill="#fff6e8" opacity="0.28" filter="url(#al-glow)"/><circle cx="600" cy="60" r="1.1" fill="#fffaf0"/>
+          <circle cx="680" cy="240" r="3" fill="#fff6e8" opacity="0.2" filter="url(#al-glow)"/><circle cx="680" cy="240" r="1.3" fill="#fffaf0"/>
+          <circle cx="140" cy="300" r="2" fill="#fff6e8" opacity="0.2" filter="url(#al-glow)"/><circle cx="140" cy="300" r="0.9" fill="#fffaf0"/>
+          <circle cx="560" cy="360" r="3.2" fill="#fff6e8" opacity="0.25" filter="url(#al-glow)"/><circle cx="560" cy="360" r="1.4" fill="#fffaf0"/>
+        </svg>
+        {% endif %}
+        <span class="al-corner tl"></span><span class="al-corner tr"></span>
+        <span class="al-corner bl"></span><span class="al-corner br"></span>
+        <div class="al-hud-tag">
+          <div class="al-desig-big">{{ featured_post.target | default: "—" }}</div>
+          <span>{{ featured_post.object_type | default: "Deep Sky" }} · {{ featured_post.constellation | default: "" }}</span>
         </div>
-        <span class="post-date">{{ post.date | date: "%b %Y" }}</span>
+        <div class="al-hud-scale"><span>10′</span><span class="al-bar"></span></div>
       </div>
+
+      <div class="al-featured-body">
+        <div class="al-kicker">⟦ Featured Session · Final ⟧</div>
+        <h2>{{ featured_post.title }}</h2>
+        <p class="al-featured-desc">{{ featured_post.description }}</p>
+        <div class="al-telem-row">
+          {% if featured_post.capture %}
+          <div class="al-it">
+            <div class="al-k">Integration</div>
+            <div class="al-v amber">{{ featured_post.capture.integration | default: "—" }}</div>
+          </div>
+          <div class="al-it">
+            <div class="al-k">Subs</div>
+            <div class="al-v">{{ featured_post.capture.frames | default: "—" }}</div>
+          </div>
+          <div class="al-it">
+            <div class="al-k">Exposure</div>
+            <div class="al-v">{{ featured_post.capture.exposure | default: "—" }}</div>
+          </div>
+          <div class="al-it">
+            <div class="al-k">Bortle</div>
+            <div class="al-v blue">{{ featured_post.capture.bortle | default: "—" }}</div>
+          </div>
+          {% endif %}
+        </div>
+        <div class="al-featured-actions">
+          <span class="al-btn-open">Open workflow →</span>
+        </div>
+      </div>
+    </a>
+
+    <!-- All sessions -->
+    {% assign rest_count = total_sessions | minus: 1 %}
+    {% if rest_count > 0 %}
+    <div class="al-sec-label al-sec-label--blue">
+      <span class="al-sec-num">§ 02</span>
+      <h2 class="al-sec-title">All Sessions</h2>
+      <div class="al-sec-rule"></div>
+      <span class="al-sec-frame">{{ rest_count }} archived</span>
+    </div>
+
+    <div class="al-session-grid">
+      {% for post in astro_posts offset: 1 %}
+      {% assign tag_colors = "is-orange,is-blue,is-amber" | split: "," %}
+      <a class="al-card{% if post.draft %} is-locked{% endif %}" href="{{ post.url | relative_url }}">
+        <div class="al-card-thumb">
+          {% if post.hero_image %}
+          <img src="{{ post.hero_image | relative_url }}" alt="{{ post.title }}" />
+          {% else %}
+          <svg viewBox="0 0 360 220" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <radialGradient id="ct-sky-{{ forloop.index }}" cx="50%" cy="50%" r="80%">
+                <stop offset="0%" stop-color="#0c1020"/><stop offset="100%" stop-color="#020308"/>
+              </radialGradient>
+              <radialGradient id="ct-ha-{{ forloop.index }}" cx="50%" cy="55%" r="65%">
+                <stop offset="0%" stop-color="#ff9a3c" stop-opacity="0"/>
+                <stop offset="35%" stop-color="#ff9a3c" stop-opacity="0.5"/>
+                <stop offset="100%" stop-color="#3a1a28" stop-opacity="0"/>
+              </radialGradient>
+              <radialGradient id="ct-oiii-{{ forloop.index }}" cx="65%" cy="32%" r="28%">
+                <stop offset="0%" stop-color="#6ad5e8" stop-opacity="0.75"/>
+                <stop offset="100%" stop-color="#1a2a40" stop-opacity="0"/>
+              </radialGradient>
+              <filter id="ct-blur-{{ forloop.index }}"><feGaussianBlur stdDeviation="0.6"/></filter>
+            </defs>
+            <rect width="360" height="220" fill="url(#ct-sky-{{ forloop.index }})"/>
+            <ellipse cx="180" cy="120" rx="190" ry="92" fill="url(#ct-ha-{{ forloop.index }})" opacity="0.9"/>
+            <ellipse cx="234" cy="70" rx="64" ry="42" fill="url(#ct-oiii-{{ forloop.index }})"/>
+            <circle cx="60" cy="36" r="2" fill="#fff6e8" opacity="0.3" filter="url(#ct-blur-{{ forloop.index }})"/><circle cx="60" cy="36" r="0.9" fill="#fffaf0"/>
+            <circle cx="120" cy="70" r="1.6" fill="#fff6e8" opacity="0.25" filter="url(#ct-blur-{{ forloop.index }})"/><circle cx="120" cy="70" r="0.7" fill="#fffaf0"/>
+            <circle cx="180" cy="50" r="2.4" fill="#fff6e8" opacity="0.3" filter="url(#ct-blur-{{ forloop.index }})"/><circle cx="180" cy="50" r="1.1" fill="#fffaf0"/>
+            <circle cx="260" cy="90" r="1.8" fill="#fff6e8" opacity="0.22" filter="url(#ct-blur-{{ forloop.index }})"/><circle cx="260" cy="90" r="0.8" fill="#fffaf0"/>
+            <circle cx="320" cy="30" r="1.4" fill="#fff6e8" opacity="0.28" filter="url(#ct-blur-{{ forloop.index }})"/><circle cx="320" cy="30" r="0.6" fill="#fffaf0"/>
+            <circle cx="80" cy="150" r="2" fill="#fff6e8" opacity="0.2" filter="url(#ct-blur-{{ forloop.index }})"/><circle cx="80" cy="150" r="0.9" fill="#fffaf0"/>
+            <circle cx="300" cy="170" r="1.6" fill="#fff6e8" opacity="0.2" filter="url(#ct-blur-{{ forloop.index }})"/><circle cx="300" cy="170" r="0.7" fill="#fffaf0"/>
+          </svg>
+          {% endif %}
+          <span class="al-session-tag">{% if post.draft %}⌗ Draft{% else %}● {{ post.date | date: "%b %Y" }}{% endif %}</span>
+          <span class="al-card-desig">{{ post.target | default: post.title | truncate: 12, "" }}</span>
+        </div>
+        <div class="al-card-body">
+          <div class="al-card-title">{{ post.title }}</div>
+          {% if post.description %}<p class="al-card-desc">{{ post.description | truncate: 120 }}</p>{% endif %}
+          {% if post.capture %}
+          <div class="al-card-telem">
+            <div class="al-it">
+              <div class="al-k">INT</div>
+              <div class="al-v amber">{{ post.capture.integration | default: "—" }}</div>
+            </div>
+            <div class="al-it">
+              <div class="al-k">SUBS</div>
+              <div class="al-v">{{ post.capture.frames | default: "—" }}</div>
+            </div>
+            <div class="al-it">
+              <div class="al-k">BORTLE</div>
+              <div class="al-v blue">{{ post.capture.bortle | default: "—" }}</div>
+            </div>
+          </div>
+          {% endif %}
+          {% if post.tags %}
+          <div class="al-card-tags">
+            {% for tag in post.tags limit: 3 %}
+            {% assign color_idx = forloop.index0 | modulo: 3 %}
+            <span class="al-tag {{ tag_colors[color_idx] }}">#{{ tag }}</span>
+            {% endfor %}
+          </div>
+          {% endif %}
+        </div>
+      </a>
       {% endfor %}
-      {% endif %}
     </div>
-  </article>
+    {% endif %}
 
-  <aside class="article-toc" aria-label="Table of contents">
-    <div class="article-toc-inner">
-      <p class="article-toc-label">On this page</p>
-      <nav class="article-toc-list" id="article-toc-list"></nav>
+    {% else %}
+
+    <!-- Empty state -->
+    <div class="al-sec-label">
+      <span class="al-sec-num">§ 01</span>
+      <h2 class="al-sec-title">Sessions</h2>
+      <div class="al-sec-rule"></div>
     </div>
-  </aside>
-</div>
+    <p style="font-family:'JetBrains Mono',monospace;font-size:13px;color:rgba(154,142,117,0.65);letter-spacing:1px;padding:24px 0;">
+      No sessions logged yet. First entry pending.
+    </p>
 
-<button class="to-top-button" id="to-top-button" type="button" aria-label="Back to top" title="Back to top">
-  ↑
-</button>
+    {% endif %}
 
-<script src="https://cdn.jsdelivr.net/npm/animejs/dist/bundles/anime.umd.min.js"></script>
-{% include article_toc_script.html %}
-{% include astrophotography_motion.html %}
+    <!-- Field method -->
+    <div class="al-sec-label">
+      <span class="al-sec-num">§ 03</span>
+      <h2 class="al-sec-title">Field Method</h2>
+      <div class="al-sec-rule"></div>
+      <span class="al-sec-frame">Pipeline overview</span>
+    </div>
+
+    <div class="al-method">
+      <div class="al-method-col">
+        <div class="al-mk">Acquisition</div>
+        <div class="al-mv">ZWO Seestar S50 (250mm f/4.8) in EQ mode with electronic field de-rotation. Short subs to control Bortle 7–8 sky glow.</div>
+      </div>
+      <div class="al-method-col">
+        <div class="al-mk">Calibration</div>
+        <div class="al-mv">WBPP 3.0 in PixInsight — auto reference selection, local normalization, SNR-weighted stacking.</div>
+      </div>
+      <div class="al-method-col">
+        <div class="al-mk">Processing</div>
+        <div class="al-mv">DBE → BlurXTerminator → NoiseXTerminator → StarXTerminator → statistical stretch → LHE → HDRMT.</div>
+      </div>
+      <div class="al-method-col">
+        <div class="al-mk">Verification</div>
+        <div class="al-mv">FWHM / eccentricity / SNR scoring per frame. Drizzle ×1 to recover detail under the Seestar's pixel scale.</div>
+      </div>
+    </div>
+
+    <footer class="al-footer">
+      <span>End of Record</span>
+      <span class="al-ok">Checksum OK</span>
+      <span>CC-BY-NC 4.0 · {{ "now" | date: "%Y" }}</span>
+    </footer>
+
+  </div><!-- /al-listing -->
+</div><!-- /astro-listing-wrap -->
+
+<button class="to-top-button" id="to-top-button" type="button" aria-label="Back to top" title="Back to top">↑</button>
+
+<script>
+(function() {
+  var btn = document.getElementById('to-top-button');
+  if (!btn) return;
+  window.addEventListener('scroll', function() {
+    btn.classList.toggle('is-visible', window.scrollY > 400);
+  }, { passive: true });
+  btn.addEventListener('click', function() {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+})();
+</script>


### PR DESCRIPTION
## Summary
- keeps the Horsehead and Flame image off-repo via the AstroBin profile link
- rewrites the PixInsight post as a reproducible recipe instead of a timestamped processing log
- adds process, settings, inspection, and output guidance for WBPP and post-processing steps

## Test
- PATH=/opt/homebrew/opt/ruby@3.2/bin:$PATH bundle exec rake