### PR TITLE
feat: tighten astrophotography listing header

### DIFF
--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -1760,12 +1760,17 @@ body.astro-page .article-shell {
 
 /* ── Header ── */
 .astro-listing-wrap .al-head {
-  padding: calc(28px * var(--al-hero-scale)) 0 22px;
+  padding: 36px 0 28px;
   border-bottom: 1px solid var(--al-rule);
   display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 24px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 48px;
   align-items: end;
+}
+.astro-listing-wrap .al-head-left {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
 .astro-listing-wrap .al-head .al-meta {
   font-family: var(--al-mono);
@@ -1773,10 +1778,9 @@ body.astro-page .article-shell {
   letter-spacing: 1.8px;
   text-transform: uppercase;
   color: var(--al-mute);
-  margin-bottom: 10px;
+  margin-bottom: 14px;
 }
 .astro-listing-wrap .al-head .al-meta .al-accent-blue { color: var(--al-blue); }
-/* Large heading: bold sans-serif with mono eyebrow via ::before */
 .astro-listing-wrap .al-head h1 {
   font-family: var(--al-display-h);
   font-weight: 700;
@@ -1784,7 +1788,7 @@ body.astro-page .article-shell {
   line-height: 0.98;
   letter-spacing: -1.5px;
   color: var(--al-cream);
-  margin-bottom: 12px;
+  margin-bottom: 18px;
   text-wrap: balance;
 }
 .astro-listing-wrap .al-head h1 .al-accent {
@@ -1800,14 +1804,24 @@ body.astro-page .article-shell {
   font-size: 16px;
   line-height: 1.55;
   color: var(--al-ink-mid);
-  max-width: 540px;
+  max-width: 460px;
+  margin: 0;
 }
+/* Stats: vertical column, label left / number right, divider on left */
 .astro-listing-wrap .al-head .al-stats {
-  display: grid;
-  grid-template-columns: auto auto auto;
-  gap: 20px 30px;
-  align-self: end;
-  padding-bottom: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  border-left: 1px solid var(--al-rule);
+  padding-left: 36px;
+  padding-bottom: 4px;
+  min-width: 200px;
+}
+.astro-listing-wrap .al-stat {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 18px;
 }
 .astro-listing-wrap .al-stat .al-k {
   font-family: var(--al-mono);
@@ -1815,13 +1829,13 @@ body.astro-page .article-shell {
   letter-spacing: 1.8px;
   text-transform: uppercase;
   color: var(--al-mute);
-  margin-bottom: 2px;
 }
 .astro-listing-wrap .al-stat .al-v {
   font-family: var(--al-mono);
   font-variant-numeric: tabular-nums;
-  font-size: calc(22px * var(--al-hero-scale));
+  font-size: 22px;
   color: var(--al-cream);
+  line-height: 1;
 }
 .astro-listing-wrap .al-stat .al-v.is-orange { color: var(--al-orange); }
 .astro-listing-wrap .al-stat .al-v.is-blue   { color: var(--al-blue); }
@@ -2166,8 +2180,8 @@ body.astro-page .article-shell {
 @media (max-width: 860px) {
   .astro-listing-wrap .al-listing { padding: 0 20px 40px; }
   .astro-listing-wrap .al-status-strip { padding-left: 20px; padding-right: 20px; }
-  .astro-listing-wrap .al-head { grid-template-columns: 1fr; }
-  .astro-listing-wrap .al-head .al-stats { grid-template-columns: repeat(3, auto); justify-content: start; gap: 14px 24px; }
+  .astro-listing-wrap .al-head { grid-template-columns: 1fr; gap: 24px; }
+  .astro-listing-wrap .al-head .al-stats { flex-direction: row; flex-wrap: wrap; border-left: none; border-top: 1px solid var(--al-rule); padding-left: 0; padding-top: 16px; min-width: 0; gap: 14px 28px; }
   .astro-listing-wrap .al-featured { grid-template-columns: 1fr; }
   .astro-listing-wrap .al-featured-img { min-height: 280px; }
   .astro-listing-wrap .al-featured-body { border-left: none; border-top: 1px solid var(--al-rule); }

--- a/astrophotography.html
+++ b/astrophotography.html
@@ -40,15 +40,15 @@ body_class: astro-page
 
     <!-- Header -->
     <header class="al-head">
-      <div>
+      <div class="al-head-left">
         <div class="al-meta">
-          Field Log · Imaging Sessions · <span class="al-accent-blue">Index 001 / {{ total_sessions }}</span>
+          Field Log · <span class="al-accent-blue">001 / {{ total_sessions }}</span>
         </div>
         <h1>Astrophotography.<br>
           <span class="al-accent">Sessions &amp; workflows.</span>
         </h1>
         <p class="al-sub">
-          A field log of imaging sessions — acquisition notes, calibration, and the processing pipeline behind each frame. Each entry runs through the full pipeline from raw subs to final stretch.
+          Acquisition notes, calibration, and the processing pipeline behind each frame — from raw subs to final stretch.
         </p>
       </div>
       <div class="al-stats">
@@ -61,8 +61,8 @@ body_class: astro-page
           <div class="al-v">{{ total_frames | default: "—" }}</div>
         </div>
         <div class="al-stat">
-          <div class="al-k">Bortle</div>
-          <div class="al-v is-amber">7–8</div>
+          <div class="al-k">Integration</div>
+          <div class="al-v is-blue">—</div>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary

Matches the latest design iteration from the updated prototype (listing header cleanup pass):

- **Meta line** trimmed to `Field Log · 001 / N` — removed the redundant "Imaging Sessions ·" segment
- **Subtitle** shortened to one sentence, `max-width` reduced to 460px
- **Stats panel** redesigned as a vertical column with a left-rule divider:
  - Label on the left, large number on the right (baseline-aligned)
  - 3 stats: Sessions / Frames / Integration (replaces Sessions/Frames/Bortle)
  - `min-width: 200px`, `padding-left: 36px`
- **`al-head-left` wrapper** added for clean `flex-direction: column` stacking
- Header top padding set to 36px (fixed), gap widened to 48px
- Responsive (≤860px): stats switch to row-wrap with top border instead of left border

## Test plan

- [ ] Visit `/astrophotography/` — header shows clean left stack + right stats column with divider rule
- [ ] Check mobile — stats wrap horizontally below the header text at ≤860px

🤖 Generated with [Claude Code](https://claude.com/claude-code)