### PR TITLE
fix: portfolio nav, post styling, and astrophotography hero

### DIFF
--- a/_layouts/astro-workflow.html
+++ b/_layouts/astro-workflow.html
@@ -21,168 +21,6 @@ layout: default
 {% endfor %}
 {% assign current_number = current_index | prepend: "00" | slice: -3, 3 %}
 
-<section class="night-post">
-  <div class="night-scene-bg" aria-hidden="true"></div>
-
-  <header class="night-mast">
-    <div class="night-brand"><em>Astrophotography</em></div>
-    <div class="night-nav">
-      <a href="{{ '/astrophotography/' | relative_url }}">← Back</a>
-      <a href="{{ '/astrophotography/' | relative_url }}">Index</a>
-      <span class="is-active">Session {{ current_number }}</span>
-      {% if next_post %}
-      <a href="{{ next_post.url | relative_url }}">Next →</a>
-      {% else %}
-      <span>Next →</span>
-      {% endif %}
-      <button class="astro-theme-toggle" aria-label="Switch light/dark mode"></button>
-    </div>
-  </header>
-
-  <div class="night-hero">
-    <div class="night-hero-media" aria-hidden="true">
-      {% if page.hero_image %}
-      <img src="{{ page.hero_image | relative_url }}" alt="{{ page.title }}" draggable="false" oncontextmenu="return false" />
-      {% else %}
-      <svg viewBox="0 0 1200 430" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <radialGradient id="night-ha" cx="50%" cy="55%" r="65%">
-            <stop offset="0%" stop-color="#d4a76a" stop-opacity="0.55" />
-            <stop offset="30%" stop-color="#a04a2e" stop-opacity="0.5" />
-            <stop offset="70%" stop-color="#3a1a18" stop-opacity="0.3" />
-            <stop offset="100%" stop-color="#07080b" stop-opacity="0" />
-          </radialGradient>
-          <radialGradient id="night-alnitak" cx="50%" cy="50%" r="50%">
-            <stop offset="0%" stop-color="#fff8e0" stop-opacity="0.95" />
-            <stop offset="35%" stop-color="#f4dca8" stop-opacity="0.5" />
-            <stop offset="100%" stop-color="#d4a76a" stop-opacity="0" />
-          </radialGradient>
-          <radialGradient id="night-oiii" cx="50%" cy="50%" r="50%">
-            <stop offset="0%" stop-color="#6fc7d4" stop-opacity="0.35" />
-            <stop offset="100%" stop-color="#6fc7d4" stop-opacity="0" />
-          </radialGradient>
-          <filter id="grain">
-            <feTurbulence baseFrequency="0.9" numOctaves="2" />
-            <feColorMatrix values="0 0 0 0 1   0 0 0 0 0.95   0 0 0 0 0.85   0 0 0 0.08 0" />
-          </filter>
-        </defs>
-        <rect width="1200" height="430" fill="#07080b" />
-        <ellipse cx="700" cy="240" rx="600" ry="240" fill="url(#night-ha)" />
-        <ellipse cx="380" cy="180" rx="180" ry="110" fill="url(#night-oiii)" />
-        <circle cx="280" cy="210" r="90" fill="url(#night-alnitak)" />
-        <circle cx="280" cy="210" r="4" fill="#fff" />
-        <line x1="180" y1="210" x2="380" y2="210" stroke="#fff" strokeWidth="0.7" opacity="0.6" />
-        <line x1="280" y1="120" x2="280" y2="300" stroke="#fff" strokeWidth="0.7" opacity="0.6" />
-        <path d="M 660 320 C 650 290, 666 260, 700 252 C 712 220, 740 204, 760 208 C 776 188, 808 188, 818 212 C 844 216, 862 240, 854 264 C 880 280, 884 312, 866 332 C 874 360, 850 396, 814 396 L 814 480 L 670 480 Z" fill="#07080b" />
-        <circle cx="140" cy="80" r="5.4" fill="#fffaf0" />
-        <circle cx="230" cy="120" r="3.9" fill="#fffaf0" />
-        <circle cx="460" cy="60" r="6" fill="#fffaf0" />
-        <circle cx="560" cy="90" r="4.4" fill="#fffaf0" />
-        <circle cx="640" cy="130" r="3.6" fill="#fffaf0" />
-        <circle cx="820" cy="70" r="7.5" fill="#fffaf0" />
-        <circle cx="920" cy="140" r="4.8" fill="#fffaf0" />
-        <circle cx="1030" cy="80" r="4.2" fill="#fffaf0" />
-        <circle cx="1090" cy="200" r="6" fill="#fffaf0" />
-        <circle cx="120" cy="260" r="3.6" fill="#fffaf0" />
-        <circle cx="200" cy="340" r="4.8" fill="#fffaf0" />
-        <circle cx="480" cy="380" r="3.6" fill="#fffaf0" />
-        <circle cx="940" cy="320" r="5.4" fill="#fffaf0" />
-        <circle cx="1070" cy="360" r="4.2" fill="#fffaf0" />
-        <rect width="1200" height="430" filter="url(#grain)" opacity="0.4" />
-      </svg>
-      {% endif %}
-    </div>
-
-    <div class="night-hero-floats" aria-hidden="true">
-      <div>RA · {% if page.ra %}{{ page.ra }}{% else %}—{% endif %} · DEC · {% if page.dec %}{{ page.dec }}{% else %}—{% endif %}</div>
-      <div class="plate">● Plate {{ current_number }}</div>
-    </div>
-
-    {% assign night_title = page.hero_title | default: page.target | default: page.title %}
-    {% assign night_subtitle = page.hero_subtitle | default: "in the stack." %}
-    <div class="night-hero-title">
-      <h1 class="night-hero-h1">
-        {{ night_title }}<br /><em>{{ night_subtitle }}</em>
-      </h1>
-      <div class="night-hero-scale">
-        ─── 10 arcmin ─── <br />
-        North ↑ &nbsp; East ←
-      </div>
-    </div>
-  </div>
-
-  <div class="night-body">
-    <main class="night-prose" id="main-content" tabindex="-1">
-      {% if page.description %}
-      <p class="intro">{{ page.description }}</p>
-      {% endif %}
-      <div>
-        {{ content }}
-      </div>
-    </main>
-
-    <aside class="night-side" id="night-sidebar">
-      {% if page.margin_note %}
-      <div class="night-note">
-        <div class="night-side-label">↳ Session note</div>
-        <div class="night-side-block">{{ page.margin_note }}</div>
-        {% if page.margin_note_date %}
-        <div class="night-note-date">{{ page.margin_note_date }}</div>
-        {% endif %}
-      </div>
-      {% endif %}
-
-      {% if page.gear %}
-      <div class="night-side-block">
-        <div class="night-side-title">── Apparatus</div>
-        <div class="night-side-label">↳ Optic</div>
-        <div>{{ page.gear.telescope | default: "—" }}</div>
-        <div class="night-side-label" style="margin-top: 12px;">↳ Camera</div>
-        <div>{{ page.gear.camera | default: "—" }}</div>
-        <div class="night-side-label" style="margin-top: 12px;">↳ Mount</div>
-        <div>{{ page.gear.mount | default: "—" }}</div>
-        <div class="night-side-label" style="margin-top: 12px;">↳ Filter</div>
-        <div>{{ page.gear.filter | default: "—" }}</div>
-      </div>
-      {% endif %}
-
-      {% if page.capture %}
-      <div class="night-side-block">
-        <div class="night-side-title">── Session</div>
-        <div class="night-side-label">↳ Integration</div>
-        <div>{{ page.capture.integration | default: "—" }}</div>
-        <div class="night-side-label" style="margin-top: 12px;">↳ Subs</div>
-        <div>{{ page.capture.frames | default: "—" }}</div>
-        <div class="night-side-label" style="margin-top: 12px;">↳ Bortle</div>
-        <div>{{ page.capture.bortle | default: "—" }}</div>
-        <div class="night-side-label" style="margin-top: 12px;">↳ Date</div>
-        <div>
-          {% if page.capture.date %}{{ page.capture.date }}{% else %}{{ page.date | date: "%b %d, %Y" }}{% endif %}
-        </div>
-      </div>
-      {% endif %}
-
-      {% if page.capture and page.capture.location %}
-      <div class="night-side-block">
-        <div class="night-side-title">── Pipeline</div>
-        <div class="night-side-label">↳ Site</div>
-        <div>{{ page.capture.location }}</div>
-        {% if page.gear and page.gear.software %}
-        <div class="night-side-label" style="margin-top: 12px;">↳ Software</div>
-        <div>{{ page.gear.software }}</div>
-        {% endif %}
-      </div>
-      {% endif %}
-    </aside>
-  </div>
-
-  <footer class="night-post-footer">
-    <span>{% if previous_post %}← {{ previous_post.target | default: previous_post.title | default: "Archive" }}{% else %}← Archive{% endif %}</span>
-    <span>● Session {{ current_number }}</span>
-    <span>{% if next_post %}{{ next_post.target | default: next_post.title | default: "Next" }} →{% else %}Index →{% endif %}</span>
-  </footer>
-</section>
-
 <div class="db-wrap post">
 
   <div class="db-bg" aria-hidden="true"></div>
@@ -190,6 +28,47 @@ layout: default
   <!-- ── HERO PANEL ── -->
   <section class="db-hero">
     <div class="db-corner-panel db-corner-panel--teal">
+
+      <!-- Image frame with title overlay -->
+      {% assign night_title = page.hero_title | default: page.target | default: page.title %}
+      {% assign night_subtitle = page.hero_subtitle | default: "in the stack." %}
+      <div class="db-image-frame">
+        {% if page.hero_image %}
+        <img src="{{ page.hero_image | relative_url }}"
+             alt="{{ page.title }}"
+             class="db-hero-img"
+             id="db-hero-img"
+             draggable="false"
+             oncontextmenu="return false" />
+        {% else %}
+        <div class="db-hero-placeholder" id="db-hero-placeholder"></div>
+        {% endif %}
+        <div class="db-hud" aria-hidden="true">
+          <div class="db-corner db-corner--tl"></div>
+          <div class="db-corner db-corner--tr"></div>
+          <div class="db-corner db-corner--bl"></div>
+          <div class="db-corner db-corner--br"></div>
+        </div>
+        <div class="db-hero-title-overlay">
+          <h1 class="db-hero-overlay-h1">{{ night_title }}<br /><em>{{ night_subtitle }}</em></h1>
+        </div>
+      </div>
+
+      <!-- Tab strip — Final / Starless / B&W -->
+      {% if page.hero_image %}
+      <div class="db-tab-strip" id="db-tab-strip">
+        <button class="db-tab db-tab--active" data-variant="final"
+                data-src="{{ page.hero_image | relative_url }}">● Final</button>
+        {% if page.starless_image %}
+        <button class="db-tab" data-variant="starless"
+                data-src="{{ page.starless_image | relative_url }}">Starless</button>
+        {% endif %}
+        {% if page.bw_image %}
+        <button class="db-tab" data-variant="bw"
+                data-src="{{ page.bw_image | relative_url }}">B&amp;W</button>
+        {% endif %}
+      </div>
+      {% endif %}
 
       <!-- Telemetry band -->
       <div class="db-telem-band">
@@ -226,55 +105,12 @@ layout: default
         {% endif %}
       </div>
 
-      <!-- Title row -->
-      <div class="db-title-row">
-        <div class="db-title-left">
-          <h1 class="db-h1">{{ page.title }}</h1>
-          {% if page.description %}<p class="db-subtitle">{{ page.description }}</p>{% endif %}
-        </div>
-      </div>
-
-      <!-- Image frame -->
-      <div class="db-image-frame">
-        {% if page.hero_image %}
-        <img src="{{ page.hero_image | relative_url }}"
-             alt="{{ page.title }}"
-             class="db-hero-img"
-             id="db-hero-img"
-             draggable="false"
-             oncontextmenu="return false" />
-        {% else %}
-        <div class="db-hero-placeholder" id="db-hero-placeholder"></div>
-        {% endif %}
-        <div class="db-hud" aria-hidden="true">
-          <div class="db-corner db-corner--tl"></div>
-          <div class="db-corner db-corner--tr"></div>
-          <div class="db-corner db-corner--bl"></div>
-          <div class="db-corner db-corner--br"></div>
-          {% if page.ra %}<div class="db-hud-ra">RA · {{ page.ra }}</div>{% endif %}
-          {% if page.dec %}<div class="db-hud-dec">DEC · {{ page.dec }}</div>{% endif %}
-          <div class="db-hud-compass">N ↑&nbsp;&nbsp;E ←</div>
-          <div class="db-hud-scale"><span>10′</span><span class="db-hud-scale-bar"></span></div>
-        </div>
-      </div>
-
-      <!-- Tab strip — Final / Starless / B&W only -->
-      {% if page.hero_image %}
-      <div class="db-tab-strip" id="db-tab-strip">
-        <button class="db-tab db-tab--active" data-variant="final"
-                data-src="{{ page.hero_image | relative_url }}">● Final</button>
-        {% if page.starless_image %}
-        <button class="db-tab" data-variant="starless"
-                data-src="{{ page.starless_image | relative_url }}">Starless</button>
-        {% endif %}
-        {% if page.bw_image %}
-        <button class="db-tab" data-variant="bw"
-                data-src="{{ page.bw_image | relative_url }}">B&amp;W</button>
-        {% endif %}
-      </div>
+      <!-- Description -->
+      {% if page.description %}
+      <div class="db-hero-desc">{{ page.description }}</div>
       {% endif %}
 
-      <!-- Action bar — only external links, no download/filler -->
+      <!-- Action bar -->
       {% if page.hero_image or page.astrobin_url %}
       <div class="db-action-bar">
         <div class="db-action-links">

--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -168,9 +168,9 @@ body.astro-page .article-shell {
   justify-self: start;
   min-width: 0;
   color: color-mix(in srgb, var(--accent) 82%, var(--ink));
-  font-size: 13px;
+  font-size: 10px;
   font-weight: 500;
-  letter-spacing: 2.4px;
+  letter-spacing: 1.8px;
   line-height: 1.2;
   text-transform: uppercase;
   white-space: nowrap;
@@ -559,6 +559,23 @@ body.astro-page .article-shell {
 .sidebar-more:hover {
   color: var(--ink);
   transform: translateY(-1px);
+}
+
+.edu {
+  padding-top: 4px;
+}
+
+.edu-degree {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+  margin-bottom: 2px;
+}
+
+.edu-school {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-faint);
 }
 
 .experience-modal {
@@ -999,6 +1016,47 @@ body.astro-page .article-shell {
   background: #000;
   aspect-ratio: 21/9;
   overflow: hidden;
+}
+
+.db-hero-title-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  padding: 0 36px 32px;
+  background: linear-gradient(
+    to top,
+    rgba(4, 6, 11, 0.72) 0%,
+    rgba(4, 6, 11, 0.28) 38%,
+    transparent 65%
+  );
+  pointer-events: none;
+}
+
+.db-hero-overlay-h1 {
+  font-family: var(--db-serif);
+  font-weight: 400;
+  font-size: clamp(32px, 4.5vw, 60px);
+  line-height: 0.98;
+  letter-spacing: 0;
+  color: #f0f3f9;
+  text-wrap: balance;
+  margin: 0;
+  text-shadow: 0 2px 24px rgba(0,0,0,0.5);
+}
+
+.db-hero-overlay-h1 em {
+  font-style: italic;
+  color: var(--db-a3);
+}
+
+.db-hero-desc {
+  font-family: var(--db-serif);
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--db-ink-sub);
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--db-rule);
 }
 
 .db-hero-img {
@@ -1665,6 +1723,248 @@ body.astro-page .article-shell {
   .db-telem-val    { font-size: 20px; }
   .db-h1           { font-size: 24px; }
 }
+
+/* ── Post / Article page ─────────────────────────────────── */
+.article-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 220px;
+  gap: 0 40px;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 40px 80px 96px;
+  align-items: start;
+}
+
+.post-wrap {
+  min-width: 0;
+}
+
+.back-link {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  text-decoration: none;
+  margin-bottom: 20px;
+  transition: color 0.14s;
+}
+.back-link:hover { color: var(--ink); }
+
+.post-header { margin-bottom: 32px; }
+
+.post-header-meta {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-faint);
+  margin-bottom: 14px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.post-h1 {
+  font-family: var(--serif);
+  font-size: clamp(28px, 4.5vw, 46px);
+  line-height: 1.08;
+  letter-spacing: -0.8px;
+  color: var(--ink);
+  margin-bottom: 14px;
+  text-wrap: balance;
+}
+
+.post-subtitle {
+  font-size: 17px;
+  color: var(--ink-soft);
+  line-height: 1.55;
+  font-weight: 300;
+  margin-bottom: 14px;
+}
+
+.post-header-tags {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.post-header-tag {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: color-mix(in srgb, var(--accent) 80%, var(--ink));
+  text-decoration: none;
+  letter-spacing: 0.6px;
+  transition: color 0.14s;
+}
+.post-header-tag:hover { color: var(--accent); }
+
+.prose {
+  font-size: 17px;
+  line-height: 1.72;
+  color: var(--ink-soft);
+}
+
+.prose h2 {
+  font-family: var(--serif);
+  font-size: clamp(20px, 2.8vw, 26px);
+  line-height: 1.2;
+  color: var(--ink);
+  letter-spacing: -0.3px;
+  margin: 40px 0 14px;
+}
+
+.prose h3 {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 28px 0 10px;
+}
+
+.prose p { margin: 0 0 20px; }
+
+.prose a {
+  color: color-mix(in srgb, var(--accent) 80%, var(--ink));
+  text-underline-offset: 3px;
+}
+.prose a:hover { color: var(--accent); }
+
+.prose strong { color: var(--ink); font-weight: 600; }
+
+.prose blockquote {
+  margin: 24px 0;
+  padding: 14px 20px;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-sub);
+  color: var(--ink-soft);
+}
+.prose blockquote p { margin: 0; }
+
+.prose pre,
+.prose code {
+  font-family: var(--mono);
+  font-size: 14px;
+}
+
+.prose pre {
+  background: var(--bg-sub);
+  border: 1px solid var(--rule);
+  padding: 16px 20px;
+  overflow-x: auto;
+  margin: 20px 0;
+  border-radius: 3px;
+}
+
+.prose code {
+  background: var(--bg-sub);
+  border: 1px solid var(--rule);
+  padding: 1px 5px;
+  border-radius: 2px;
+}
+.prose pre code { background: none; border: none; padding: 0; }
+
+.prose ol,
+.prose ul {
+  padding-left: 22px;
+  margin: 0 0 20px;
+}
+
+.prose li { margin-bottom: 6px; }
+
+.prose hr {
+  border: none;
+  border-top: 1px solid var(--rule);
+  margin: 36px 0;
+}
+
+/* Article TOC */
+.article-toc {
+  position: sticky;
+  top: calc(var(--nav-h) + 28px);
+  align-self: start;
+  max-height: calc(100vh - var(--nav-h) - 56px);
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--rule) transparent;
+}
+
+.article-toc-inner { padding: 0; }
+
+.article-toc-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 12px;
+}
+
+.article-toc-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* To-top button */
+.to-top-button {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-sub);
+  border: 1px solid var(--rule);
+  color: var(--ink-faint);
+  font-size: 16px;
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.14s, background 0.14s;
+}
+.to-top-button:hover { color: var(--ink); background: var(--rule); }
+.to-top-button.is-visible { display: flex; }
+
+/* Progress bar */
+.progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 2px;
+  background: var(--accent);
+  z-index: 200;
+  width: 0%;
+  transition: width 0.1s linear;
+}
+
+@media (max-width: 1100px) {
+  .article-shell {
+    padding: 32px 28px 80px;
+    grid-template-columns: minmax(0, 1fr) 200px;
+    gap: 0 28px;
+  }
+}
+
+@media (max-width: 860px) {
+  .article-shell {
+    grid-template-columns: 1fr;
+    padding: 28px 20px 72px;
+  }
+  .article-toc { display: none; }
+}
+
+@media (max-width: 480px) {
+  .article-shell {
+    padding: 20px 14px 56px;
+  }
+  .post-h1 {
+    font-size: 28px;
+  }
+  .prose { font-size: 16px; }
+}
+
+/* ─────────────────────────────────────────────────────────── */
 
 @media (max-width: 1100px) {
   .home-wrap {


### PR DESCRIPTION
## Summary

- Reduced nav subtitle font (`SENIOR SOFTWARE ENGINEER · SUNNYVALE CA`) from 13px → 10px so it reads clearly subordinate to the centered name
- Added explicit sizing for the education block in the sidebar (`.edu-degree` 13px, `.edu-school` 11px mono) — previously unstyled and inheriting oversized defaults
- Added full post page CSS: two-column `article-shell` grid, `prose` typography, `back-link`, TOC sidebar, to-top button, and progress bar — blog posts were rendering as unstyled edge-to-edge text
- Removed the entire duplicate `night-post` section from `astro-workflow.html` that was rendering a second old theme below the dashboard on every astrophotography post
- Redesigned the astrophotography hero: image + serif title overlay (bottom-left gradient) + Final/Starless/B&W tab strip as one unified block, with telemetry band below
- Stripped the astrophotography nav bar down to just the theme toggle

## Test plan

- [ ] Portfolio home: nav subtitle visually smaller than center name; education block in sidebar is compact
- [ ] Blog post (e.g. `/posts/building-cosmophile-...`): has a readable content column, proper heading sizes, no edge-to-edge raw text
- [ ] Astrophotography post (`/posts/horsehead-flame-nebula-wbpp-workflow/`): single unified theme, no duplicate layout at bottom; hero shows image with title overlay; Final/Starless/B&W tabs switch the image
- [ ] Theme toggle works on astrophotography post
- [ ] No regressions on home page or astrophotography listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)