### PR TITLE
fix: restore After Dark warm palette and correct hero layout

### DIFF
--- a/_layouts/astro-workflow.html
+++ b/_layouts/astro-workflow.html
@@ -29,47 +29,6 @@ layout: default
   <section class="db-hero">
     <div class="db-corner-panel db-corner-panel--teal">
 
-      <!-- Image frame with title overlay -->
-      {% assign night_title = page.hero_title | default: page.target | default: page.title %}
-      {% assign night_subtitle = page.hero_subtitle | default: "in the stack." %}
-      <div class="db-image-frame">
-        {% if page.hero_image %}
-        <img src="{{ page.hero_image | relative_url }}"
-             alt="{{ page.title }}"
-             class="db-hero-img"
-             id="db-hero-img"
-             draggable="false"
-             oncontextmenu="return false" />
-        {% else %}
-        <div class="db-hero-placeholder" id="db-hero-placeholder"></div>
-        {% endif %}
-        <div class="db-hud" aria-hidden="true">
-          <div class="db-corner db-corner--tl"></div>
-          <div class="db-corner db-corner--tr"></div>
-          <div class="db-corner db-corner--bl"></div>
-          <div class="db-corner db-corner--br"></div>
-        </div>
-        <div class="db-hero-title-overlay">
-          <h1 class="db-hero-overlay-h1">{{ night_title }}<br /><em>{{ night_subtitle }}</em></h1>
-        </div>
-      </div>
-
-      <!-- Tab strip — Final / Starless / B&W -->
-      {% if page.hero_image %}
-      <div class="db-tab-strip" id="db-tab-strip">
-        <button class="db-tab db-tab--active" data-variant="final"
-                data-src="{{ page.hero_image | relative_url }}">● Final</button>
-        {% if page.starless_image %}
-        <button class="db-tab" data-variant="starless"
-                data-src="{{ page.starless_image | relative_url }}">Starless</button>
-        {% endif %}
-        {% if page.bw_image %}
-        <button class="db-tab" data-variant="bw"
-                data-src="{{ page.bw_image | relative_url }}">B&amp;W</button>
-        {% endif %}
-      </div>
-      {% endif %}
-
       <!-- Telemetry band -->
       <div class="db-telem-band">
         <div class="db-telem-designation">
@@ -105,9 +64,48 @@ layout: default
         {% endif %}
       </div>
 
-      <!-- Description -->
-      {% if page.description %}
-      <div class="db-hero-desc">{{ page.description }}</div>
+      <!-- Title row -->
+      <div class="db-title-row">
+        <div class="db-title-left">
+          <h1 class="db-h1">{{ page.title }}</h1>
+          {% if page.description %}<p class="db-subtitle">{{ page.description }}</p>{% endif %}
+        </div>
+      </div>
+
+      <!-- Image frame -->
+      <div class="db-image-frame">
+        {% if page.hero_image %}
+        <img src="{{ page.hero_image | relative_url }}"
+             alt="{{ page.title }}"
+             class="db-hero-img"
+             id="db-hero-img"
+             draggable="false"
+             oncontextmenu="return false" />
+        {% else %}
+        <div class="db-hero-placeholder" id="db-hero-placeholder"></div>
+        {% endif %}
+        <div class="db-hud" aria-hidden="true">
+          <div class="db-corner db-corner--tl"></div>
+          <div class="db-corner db-corner--tr"></div>
+          <div class="db-corner db-corner--bl"></div>
+          <div class="db-corner db-corner--br"></div>
+        </div>
+      </div>
+
+      <!-- Tab strip — Final / Starless / B&W -->
+      {% if page.hero_image %}
+      <div class="db-tab-strip" id="db-tab-strip">
+        <button class="db-tab db-tab--active" data-variant="final"
+                data-src="{{ page.hero_image | relative_url }}">● Final</button>
+        {% if page.starless_image %}
+        <button class="db-tab" data-variant="starless"
+                data-src="{{ page.starless_image | relative_url }}">Starless</button>
+        {% endif %}
+        {% if page.bw_image %}
+        <button class="db-tab" data-variant="bw"
+                data-src="{{ page.bw_image | relative_url }}">B&amp;W</button>
+        {% endif %}
+      </div>
       {% endif %}
 
       <!-- Action bar -->
@@ -221,8 +219,8 @@ layout: default
       </div>
       {% endif %}
 
-      <div class="db-corner-panel db-corner-panel--teal db-corner-panel--small">
-        <div class="db-panel-header db-panel-header--teal"><span>⟦ Object ⟧</span></div>
+      <div class="db-corner-panel db-corner-panel--amber db-corner-panel--small">
+        <div class="db-panel-header db-panel-header--amber"><span>⟦ Object ⟧</span></div>
         <div class="db-sidebar-table">
           {% if page.target %}<div class="db-srow"><span class="db-skey">TGT</span><span class="db-sval">{{ page.target }}</span></div>{% endif %}
           {% if page.constellation %}<div class="db-srow"><span class="db-skey">Const</span><span class="db-sval">{{ page.constellation }}</span></div>{% endif %}

--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -701,15 +701,15 @@ body.astro-page .article-shell {
 
 /* ── Tokens ── */
 .db-wrap {
-  --db-bg:      #04060b;
-  --db-ink:     #c8d3e6;
-  --db-ink-sub: #aeb8cc;
-  --db-mute:    rgba(170,190,220,0.45);
-  --db-rule:    rgba(94,197,193,0.14);
-  --db-panel:   rgba(8,12,22,0.78);
-  --db-a1:      #e85a4f;
-  --db-a2:      #5ec5c1;
-  --db-a3:      #8aa9ff;
+  --db-bg:      #14100a;
+  --db-ink:     #f1e6d2;
+  --db-ink-sub: #b3a489;
+  --db-mute:    rgba(138,122,98,0.9);
+  --db-rule:    rgba(217,132,80,0.18);
+  --db-panel:   rgba(28,22,16,0.78);
+  --db-a1:      #ff8a42;
+  --db-a2:      #ffc070;
+  --db-a3:      #9fc7ff;
   --db-mono:    'JetBrains Mono', ui-monospace, monospace;
   --db-serif:   'Source Serif 4', 'Source Serif Pro', Georgia, serif;
 
@@ -727,8 +727,8 @@ body.astro-page .article-shell {
   pointer-events: none;
   z-index: 0;
   background-image:
-    radial-gradient(rgba(255,255,255,0.55) 0.5px, transparent 0.5px),
-    repeating-linear-gradient(0deg, rgba(94,197,193,0.03) 0 1px, transparent 1px 4px);
+    radial-gradient(rgba(255,220,180,0.4) 0.5px, transparent 0.5px),
+    repeating-linear-gradient(0deg, rgba(217,132,80,0.03) 0 1px, transparent 1px 4px);
   background-size: 220px 220px, 100% 100%;
   opacity: 0.65;
 }
@@ -890,9 +890,10 @@ body.astro-page .article-shell {
   z-index: 2;
 }
 
-.db-corner-panel--teal { --db-corner-color: var(--db-a2); }
-.db-corner-panel--blue { --db-corner-color: var(--db-a3); }
-.db-corner-panel--red  { --db-corner-color: var(--db-a1); }
+.db-corner-panel--teal  { --db-corner-color: var(--db-a1); }
+.db-corner-panel--amber { --db-corner-color: var(--db-a2); }
+.db-corner-panel--blue  { --db-corner-color: var(--db-a3); }
+.db-corner-panel--red   { --db-corner-color: var(--db-a1); }
 
 /* Panel header bar */
 .db-panel-header {
@@ -906,9 +907,10 @@ body.astro-page .article-shell {
   text-transform: uppercase;
 }
 
-.db-panel-header--teal { color: var(--db-a2); background: rgba(94,197,193,0.04); }
-.db-panel-header--blue { color: var(--db-a3); background: rgba(138,169,255,0.04); }
-.db-panel-header--red  { color: var(--db-a1); background: rgba(232,90,79,0.04); }
+.db-panel-header--teal  { color: var(--db-a1); background: rgba(255,138,66,0.05); }
+.db-panel-header--amber { color: var(--db-a2); background: rgba(255,192,112,0.05); }
+.db-panel-header--blue  { color: var(--db-a3); background: rgba(159,199,255,0.05); }
+.db-panel-header--red   { color: var(--db-a1); background: rgba(255,138,66,0.05); }
 
 .db-panel-header--small { padding: 6px 12px; font-size: 9px; }
 .db-panel-right { color: var(--db-mute); }
@@ -1203,8 +1205,8 @@ body.astro-page .article-shell {
   padding: 9px 12px;
   border: 0;
   cursor: pointer;
-  background: rgba(8,12,22,0.85);
-  color: #cfd6e4;
+  background: rgba(28,22,16,0.85);
+  color: var(--db-ink-sub);
   font-family: var(--db-mono);
   font-size: 10px;
   letter-spacing: 1.6px;
@@ -1212,8 +1214,8 @@ body.astro-page .article-shell {
   transition: background 0.12s, color 0.12s;
 }
 
-.db-tab:hover  { background: rgba(138,169,255,0.1); color: var(--db-a3); }
-.db-tab--active { background: var(--db-a2); color: #04060b; font-weight: 600; }
+.db-tab:hover  { background: rgba(255,138,66,0.1); color: var(--db-a1); }
+.db-tab--active { background: var(--db-a1); color: #14100a; font-weight: 600; }
 
 /* ── Action bar ── */
 .db-action-bar {


### PR DESCRIPTION
## Summary

- Switches the astrophotography post theme tokens from cold blue (`#04060b`) to the correct warm dark palette (`#14100a`) matching the reference design — orange/amber/sky-blue accents instead of teal/blue
- Fixes hero block order to match reference: telemetry band → title + description → image → tab strip (was: tabs above telemetry, title overlaid on image)
- Tab strip active state is now orange instead of teal
- Sidebar panels now use correct bracket colors: Gear = orange, Object = amber, Capture = blue
- Adds `--amber` panel variant to CSS

## Test plan

- [ ] Astrophotography post has warm dark background (not cold blue/black)
- [ ] Telemetry band appears first with orange-accented values
- [ ] Title "Horsehead and Flame Nebulae..." appears below telemetry, above image
- [ ] Final/Starless/B&W tabs are below the image, active tab is orange
- [ ] Sidebar shows orange ⟦ Gear ⟧, amber ⟦ Object ⟧, blue ⟦ Capture Log ⟧ panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)